### PR TITLE
zensical:feature - allow running as a script with `pyton -m zensical`

### DIFF
--- a/python/zensical/__main__.py
+++ b/python/zensical/__main__.py
@@ -1,0 +1,28 @@
+# Copyright (c) Zensical LLC <https://zensical.org>
+
+# SPDX-License-Identifier: MIT
+# Third-party contributions licensed under CLA
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+# Allow running as a script, with `python -m zensical`.
+from zensical.main import cli
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()


### PR DESCRIPTION
By the way I notice that submodules are implicitly public. Do we have a statement that the API is not stable, or that it is to be considered internal, and shouldn't be relied on? Python devs will implicitly consider that any (sub)module *not* starting with `_` is public.