### PR TITLE
zensical:fix GH Action not working, not created

### DIFF
--- a/python/zensical/bootstrap/.github/workflows/docs.yml
+++ b/python/zensical/bootstrap/.github/workflows/docs.yml
@@ -1,21 +1,27 @@
-name: docs
+name: Documentation
 on:
   push:
     branches:
       - master
       - main
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 jobs:
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/configure-pages@v5
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: pip install zensical
-      - run: zensical build
+      - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site

--- a/python/zensical/main.py
+++ b/python/zensical/main.py
@@ -168,10 +168,17 @@ def new_project(directory: str | None, **kwargs):
         os.makedirs(directory)
 
     package_dir = os.path.dirname(os.path.abspath(__file__))
-    shutil.copy(os.path.join(package_dir, "bootstrap/zensical.toml"), directory)
+    shutil.copy(
+        os.path.join(package_dir, "bootstrap/zensical.toml"),
+        directory
+    )
     shutil.copytree(
         os.path.join(package_dir, "bootstrap/docs"),
-        os.path.join(directory, "docs"),
+        os.path.join(directory, "docs")
+    )
+    shutil.copytree(
+        os.path.join(package_dir, "bootstrap/.github"),
+        os.path.join(directory, ".github")
     )
 
 


### PR DESCRIPTION
Updated the GH Action workflow in the template and added code to copy it to a new project. 
Not sure if the code for copying things can be simplified. I thought I could just `shutils.copytree` the whole `bootstrap/` but that won't work if the target directory is `.`, which already exists.

Tested the result and it seems to work fine. 