### PR TITLE
workspace:fix - open browser only after server starts

### DIFF
--- a/python/zensical/main.py
+++ b/python/zensical/main.py
@@ -38,6 +38,10 @@ from zensical import build, serve, version
 # ----------------------------------------------------------------------------
 # Commands
 # ----------------------------------------------------------------------------
+
+
+# Wait for the server to be available before opening the browser - we'll remove
+# this hack once the server can signal that it's ready for serving.
 def open_browser(url):
     def _open_browser(url):
         while True:


### PR DESCRIPTION
This ensures that the the server is actually started before opening the browser.
Without this, the browser can, and generally does, open before the server
has started, resulting in a server not found type of error. The result is the
user has to manually reload the browser on the first load.
