### PR TITLE
workspace:fix - maturin source dist .github dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,8 @@ python-source = "python"
 features = ["pyo3/extension-module"]
 manifest-path = "crates/zensical/Cargo.toml"
 include = [
-  "python/zensical/templates/**/*",
   "python/zensical/bootstrap/**/*",
+  "python/zensical/templates/**/*",
   "LICENSE.md",
 ]
 


### PR DESCRIPTION
Source distribution does not include directory
`python/zensical/bootstrap/.github`. This it probably because
maturin excludes dot dirs?

This PR adds the `bootstrap` dir to maturin's include list.
