### PR TITLE
fix: missing commas in bootstrap template

### DIFF
--- a/python/zensical/bootstrap/zensical.toml
+++ b/python/zensical/bootstrap/zensical.toml
@@ -194,7 +194,7 @@ features = [
     # In order to provide a better user experience on slow connections when
     # using instant navigation, a progress indicator can be enabled.
     # https://zensical.org/docs/setup/navigation/#progress-indicator
-    #"navigation.instant.progress"
+    #"navigation.instant.progress",
 
     # When navigation paths are activated, a breadcrumb navigation is rendered
     # above the title of each page


### PR DESCRIPTION
Add missing commas after commented toc.follow and toc.integrate entries to prevent syntax errors when enabling these options