### PR TITLE
zensical-serve:fix - deduplicate server bind addrs

### DIFF
--- a/crates/zensical-serve/src/server/builder.rs
+++ b/crates/zensical-serve/src/server/builder.rs
@@ -106,6 +106,8 @@ where
     where
         A: ToSocketAddrs,
     {
+        // The underlying system call might returned the same socket address
+        // multiple times, which is why we need to deduplicate them
         let addrs = addr.to_socket_addrs()?;
         for addr in addrs {
             if !self.addrs.contains(&addr) {


### PR DESCRIPTION
`ToSocketAddrs` might sometimes return duplicate addresses [^1][1]
[^2][2]. This results in the server trying to open socket multiple times
and failing with "Address already in use".

This PR fixes it by deduplicating address in `server::Builder::bind`.

It does this in O(n^2) time, but this should not matter here.

[1]: https://users.rust-lang.org/t/a/2071
[2]: https://stackoverflow.com/questions/40782933

Signed-off-by: aljazerzen <aljaz@erzen.si>
