### PR TITLE
Sort pages with order keyword in front matter

### DIFF
--- a/crates/zensical/src/structure/nav.rs
+++ b/crates/zensical/src/structure/nav.rs
@@ -279,10 +279,20 @@ impl From<Chunk<Id, Page>> for Navigation {
         let mut items: Vec<NavigationItem> = Vec::new();
 
         // Convert chunk into a vector for easier processing, and sort pages by
-        // the exact same method that MkDocs uses
+        // the exact same method that MkDocs uses, with support for ordering
         let mut pages = Vec::from_iter(pages);
-        pages.sort_by_key(|item| file_sort_key(&item.id));
-
+        pages.sort_by_key(|item| {
+            let order = item.data.meta.get("order").and_then(|meta| {
+                if let crate::structure::dynamic::Dynamic::Integer(value) = meta {
+                    Some(*value)
+                } else {
+                    None
+                }
+            });
+            
+            let (parents, not_index, filename) = file_sort_key(&item.id);
+            (parents, order, not_index, filename)
+        });
         // There can only be pages, no URLs, since we're auto-populating the
         // navigation from the files in the docs directory
         for page in pages {

--- a/crates/zensical/src/structure/nav/meta.rs
+++ b/crates/zensical/src/structure/nav/meta.rs
@@ -42,6 +42,8 @@ pub struct NavigationMeta {
     pub icon: Option<String>,
     /// Page status.
     pub status: Option<String>,
+    /// Page order for navigation sorting
+    pub order: Option<i64>,
 }
 
 // ----------------------------------------------------------------------------
@@ -53,9 +55,17 @@ impl From<PageMeta> for NavigationMeta {
     fn from(meta: PageMeta) -> Self {
         let icon = meta.get("icon").cloned();
         let status = meta.get("status").cloned();
+        let order = meta.get("order").cloned();
         NavigationMeta {
             icon: icon.map(|meta| meta.to_string()),
             status: status.map(|meta| meta.to_string()),
+            order: order.and_then(|meta| {
+                if let crate::structure::dynamic::Dynamic::Integer(value) = meta {
+                    Some(value)
+                } else {
+                    None
+                }
+            }),
         }
     }
 }


### PR DESCRIPTION
# Idea

Ordering by telling page which order to be sorted in, in the navigation

> I literally just read as I was putting this together that something better is coming #76, but in the interim this works for me.

## Example

`alpacas.md`
```
---
title: Alpacas
order: 2
---
```
`bears.md`
```
---
title: Bears
order: 3
---
```
`zebras.md`
```
---
title: Zebras
order: 1
---
```

<img width="522" height="267" alt="image" src="https://github.com/user-attachments/assets/2b05b6b8-f1fd-4dd1-aae2-1ebbdb7cbccb" />

I do realize that this might not be the best approach, but it felt intuitive to me!

Thanks for making Zensical, it's great!