### PR TITLE
Check individual gh-actions files

### DIFF
--- a/python/zensical/main.py
+++ b/python/zensical/main.py
@@ -138,7 +138,7 @@ def execute_serve(config_file: str | None, **kwargs):
     type=click.Path(file_okay=False, dir_okay=True, writable=True),
     required=False,
 )
-def new_project(directory: str | None):
+def new_project(directory: str | None, **kwargs):
     """
     Create a new template project in the current directory or in the given
     directory.


### PR DESCRIPTION
When the `.github` directory is present, the CLI aborts the `new` command.

This PR therefore attempts to not let the initialization fail if only a `.github` directory is present, as different `gh-actions` could be setup already in the user's project. Instead, all files that would be copied from the `bootstrap` directory are checked in the user's project if they exist.

I hope my changes are helpful.


P.S.: Thanks for this great project. I can't wait to finally use it in a project.