### PR TITLE
refactor: Change name under which the links processor is registered

### DIFF
--- a/python/zensical/extensions/links.py
+++ b/python/zensical/extensions/links.py
@@ -123,7 +123,7 @@ class LinksExtension(Extension):
         # after our treeprocessor, so we can check the original Markdown URIs
         # before they are resolved to URLs.
         processor = LinksProcessor(md, self.path, self.use_directory_urls)
-        md.treeprocessors.register(processor, "relpath", 0)
+        md.treeprocessors.register(processor, "zrelpath", 0)
 
 
 # -----------------------------------------------------------------------------

--- a/python/zensical/extensions/preview.py
+++ b/python/zensical/extensions/preview.py
@@ -57,7 +57,7 @@ class PreviewProcessor(Treeprocessor):
         """
         Run the treeprocessor.
         """
-        at = self.md.treeprocessors.get_index_for_name("relpath")
+        at = self.md.treeprocessors.get_index_for_name("zrelpath")
 
         # Hack: Python Markdown has no notion of where it is, i.e., which file
         # is being processed. This seems to be a deliberate design decision, as


### PR DESCRIPTION
Other Markdown extensions sometimes check the presence/absence of processors by their name. The name `relpath` is the same as in MkDocs, but the signature of both processors are different. This triggered a TypeError in mkdocstrings when running under Zensical.

If not using the same name as in MkDocs surfaces new errors, I say: good, lets fix those.

Feel free to pick a different name, I was quite uninspired :smile: 

(also, I followed what you told me and went with a classic conventional commit message, feel free to change it when squashing)