### PR TITLE
Follow symlinks in walker

### DIFF
--- a/crates/zensical-watch/src/agent/manager.rs
+++ b/crates/zensical-watch/src/agent/manager.rs
@@ -764,7 +764,7 @@ where
 {
     WalkDir::new(path)
         .follow_root_links(false)
-        .follow_links(false)
+        .follow_links(true)
         .into_iter()
         // For now we skip hidden directories to speed up the build, since we
         // do not need to watch icons, but in general we need to find a better


### PR DESCRIPTION
Resolves #142.

I think we should follow symlinks here.

And possibly also for `follow_root_links`.

But this fixes my issue at least.