### PR TITLE
zensical:fix - Add deployment id to GitHub Actions workflow

### DIFF
--- a/python/zensical/bootstrap/.github/workflows/docs.yml
+++ b/python/zensical/bootstrap/.github/workflows/docs.yml
@@ -26,4 +26,4 @@ jobs:
         with:
           path: site
       - uses: actions/deploy-pages@v4
-      - id: deployment
+        id: deployment


### PR DESCRIPTION
Fixes the missing `id: deployment` in the Pages deployment step.

Without this, the workflow cannot access
```
url: ${{ steps.deployment.outputs.page_url }}
```