### PR TITLE
zensical:fix - navigation.indexes matches filenames containing 'index'

### DIFF
--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -595,7 +595,7 @@ def _is_index(path: str) -> bool:
     """
     Returns, whether the given path points to a section index.
     """
-    return path.endswith(("index.md", "README.md"))
+    return os.path.basename(path) in ("index.md", "README.md")
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #168

The `navigation.indexes` feature was incorrectly treating any file with "index" in its filename (e.g., `diagram-index.md`, `api-index.md`) as a section index page, causing it to be consumed as the section header link instead of appearing as a separate navigation item.

## Root Cause

The `_is_index()` function in `python/zensical/config.py` used `str.endswith()` on the full path:

```python
return path.endswith(("index.md", "README.md"))
```

This matched paths like `about/diagram-index.md` because the string ends with "index.md".

## Fix

Changed to use `os.path.basename()` to extract the filename before checking:

```python
return os.path.basename(path) in ("index.md", "README.md")
```

This aligns with the Rust implementation in `crates/zensical/src/structure/nav.rs` which correctly uses exact equality on the filename component.

## Behavior Change

| Path | Before | After |
|------|--------|-------|
| `index.md` | ✅ True | ✅ True |
| `about/index.md` | ✅ True | ✅ True |
| `README.md` | ✅ True | ✅ True |
| `diagram-index.md` | ❌ True | ✅ False |
| `about/api-index.md` | ❌ True | ✅ False |