### PR TITLE
Disable Jekyll processing for GitHub Pages deployment

### DIFF
--- a/python/zensical/bootstrap/.github/workflows/docs.yml
+++ b/python/zensical/bootstrap/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ jobs:
           python-version: 3.x
       - run: pip install zensical
       - run: zensical build --clean
+      - run: touch site/.nojekyll
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site


### PR DESCRIPTION
Added a step in python/zensical/bootstrap/.github/workflows/docs.yml to create a .nojekyll file on deployment.  

This stops GitHub Pages from applying Jekyll rules. A minor change, but it keeps the deployment clean since we don’t use Jekyll.
