### PR TITLE
fix:zensical encoding errors reading mkdocs.yml (#189)

### DIFF
--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -98,7 +98,7 @@ def parse_zensical_config(path: str) -> dict:
 def parse_mkdocs_config(path: str) -> dict:
     """Parse mkdocs.yml configuration file."""
     global _CONFIG  # noqa: PLW0603
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         config = _yaml_load(f)
 
     # Apply defaults and return parsed configuration
@@ -756,7 +756,7 @@ def _yaml_load(
             raise ConfigurationError(
                 f"Inherited config file '{relpath}' doesn't exist at '{abspath}'."
             )
-        with open(abspath) as fd:
+        with open(abspath, encoding="utf-8") as fd:
             parent = _yaml_load(fd, loader)
         config = always_merger.merge(parent, config)
 


### PR DESCRIPTION
`mkdocs.yml` files were not read with UTF-8 encoding explicitly specified, which causes problems on Windows, see #189. I did find two locations where we needed to add the encoding in.