### PR TITLE
zensical:fix - Make kwargs unpacking for custom fence/toc slugify function more robust

### DIFF
--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -368,13 +368,13 @@ def _apply_defaults(config: dict, path: str) -> dict:
     tabbed = config["mdx_configs"].get("pymdownx.tabbed", {})
     if isinstance(tabbed.get("slugify"), dict):
         object = tabbed["slugify"].get("object", "pymdownx.slugs.slugify")
-        tabbed["slugify"] = _resolve(object)(**tabbed["slugify"].get("kwds"))
+        tabbed["slugify"] = _resolve(object)(**tabbed["slugify"].get("kwds", {}))
 
     # Table of contents extension configuration - resolve slugification function
     toc = config["mdx_configs"]["toc"]
     if isinstance(toc.get("slugify"), dict):
         object = toc["slugify"].get("object", "pymdownx.slugs.slugify")
-        toc["slugify"] = _resolve(object)(**toc["slugify"].get("kwds"))
+        toc["slugify"] = _resolve(object)(**toc["slugify"].get("kwds", {}))
 
     # Superfences extension configuration - resolve format function
     superfences = config["mdx_configs"].get("pymdownx.superfences", {})


### PR DESCRIPTION
Otherwise if someone specifies a custom function with the mapping syntax, but no `kwds`, Python would try to unpack `None` and it would fail. We could accept that as a user error, but I figured we can just be more defensive.