### PR TITLE
zensical:fix - fix handling of root-relative (absolute) links i.e sta…

### DIFF
--- a/python/zensical/extensions/links.py
+++ b/python/zensical/extensions/links.py
@@ -74,7 +74,7 @@ class LinksProcessor(Treeprocessor):
 
             # Parse URL and skip everything that is not a relative link
             url = urlparse(value)
-            if url.scheme or url.netloc or value.startswith("/"):
+            if url.scheme or url.netloc:
                 continue
 
             # Leave anchors that go to the same page as they are


### PR DESCRIPTION
The line modified catches now catches: 

1. url scenarios
2. netloc scenarios, 
3. (the fix) catches absolute-links (root-relative-links)

