### PR TITLE
chore: release v0.0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-serve"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "base64",
  "crossbeam",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-watch"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-zensical-serve = { version = "0.0.0", path = "crates/zensical-serve" }
-zensical-watch = { version = "0.0.0", path = "crates/zensical-watch" }
+zensical-serve = { version = "0.0.1", path = "crates/zensical-serve" }
+zensical-watch = { version = "0.0.1", path = "crates/zensical-watch" }
 
 ahash = "0.8.12"
 base64 = "0.22.1"

--- a/crates/zensical-serve/Cargo.toml
+++ b/crates/zensical-serve/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-serve"
-version = "0.0.0"
+version = "0.0.1"
 description = "HTTP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical-watch/Cargo.toml
+++ b/crates/zensical-watch/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-watch"
-version = "0.0.0"
+version = "0.0.1"
 description = "Resilient file watcher"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.11"
+version = "0.0.12"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary
    
This release fixes several issue with `mkdocs.yml` parsing, problems with `zensical new`, and other bugs. It's also the first release that goes through our new release workflow powered by mono, our new mono repository automation tool.