### PR TITLE
chore: release v0.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.12"
+version = "0.0.13"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This release updates the [user interface] to [v0.0.2], which includes various improvements and bug fixes, and ships 132 icons. It might be a breaking change, as Simple icons removed 37 icons in their latest release. See the [v0.0.2] release notes for details.

[user interface]: https://github.com/zensical/ui
[v0.0.2]: https://github.com/zensical/ui/releases/tag/v0.0.2

### Highlights

- Add GitHub repository in drawer on mobile in modern theme
- Add 132 new icons (and delete 44 icons, as Simple icons removed them)
- Fix issues related to keyboard shortcuts (printing and search input)
- Fix language selector escaping viewport on mobile when too wide
