### PR TITLE
chore: upgrade to mono v0.0.5

### DIFF
--- a/.mono.toml
+++ b/.mono.toml
@@ -22,5 +22,6 @@
 # IN THE SOFTWARE.
 
 [changeset.scopes]
-compat = "python"
-ui = "scripts"
+compat = "python/**"
+docker = "Dockerfile"
+ui = "scripts/**"


### PR DESCRIPTION
The way scopes are handled in `.mono.toml` changed, see [v0.0.5] release notes.

[v0.0.5]: https://github.com/zensical/mono/releases/tag/v0.0.5