### PR TITLE
chore: release v0.0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.13"
+version = "0.0.14"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This release includes the official Docker image for Zensical, and fixes problems with hanging builds on Linux and Windows, as well as the build cache not being invalidatedwhen templates were changed in overrides.

You can pull and run the Docker image with:

``` sh
docker run --rm -it -p 8000:8000 -v ${PWD}:/docs zensical/zensical
```

### Highlight

- Official Docker image for Zensical
- Fix hanging builds on Linux and Windows
- Fix stale build caches when templates are changed