### PR TITLE
chore: update bootstrap copyright year to 2026

### DIFF
--- a/python/zensical/bootstrap/zensical.toml
+++ b/python/zensical/bootstrap/zensical.toml
@@ -34,7 +34,7 @@ site_author = "<your name here>"
 #
 # Read more: https://zensical.org/docs/setup/basics/#copyright
 copyright = """
-Copyright &copy; 2025 The authors
+Copyright &copy; 2026 The authors
 """
 
 # Zensical supports both implicit navigation and explicitly defined navigation.


### PR DESCRIPTION
Makes sure that new Zensical projects start with an up-to-date copyright year.