### PR TITLE
feat: allow arbitrary admonition icon keys

### DIFF
--- a/crates/zensical/src/config/theme.rs
+++ b/crates/zensical/src/config/theme.rs
@@ -118,39 +118,9 @@ pub struct Icon {
     /// Next page icon.
     pub next: Option<String>,
     /// Admonition icons.
-    pub admonition: Option<AdmonitionIcon>,
+    pub admonition: BTreeMap<String, String>,
     /// Tag icons.
     pub tag: BTreeMap<String, String>,
-}
-
-/// Admonition icons.
-#[derive(Debug, Hash, FromPyObject, Serialize)]
-#[pyo3(from_item_all)]
-pub struct AdmonitionIcon {
-    /// Admonition `note` icon.
-    pub note: Option<String>,
-    /// Admonition `abstract` icon.
-    pub r#abstract: Option<String>,
-    /// Admonition `info` icon.
-    pub info: Option<String>,
-    /// Admonition `tip` icon.
-    pub tip: Option<String>,
-    /// Admonition `success` icon.
-    pub success: Option<String>,
-    /// Admonition `question` icon.
-    pub question: Option<String>,
-    /// Admonition `warning` icon.
-    pub warning: Option<String>,
-    /// Admonition `failure` icon.
-    pub failure: Option<String>,
-    /// Admonition `danger` icon.
-    pub danger: Option<String>,
-    /// Admonition `bug` icon.
-    pub bug: Option<String>,
-    /// Admonition `example` icon.
-    pub example: Option<String>,
-    /// Admonition `quote` icon.
-    pub quote: Option<String>,
 }
 
 // ----------------------------------------------------------------------------

--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -262,18 +262,10 @@ def _apply_defaults(config: dict, path: str) -> dict:
 
     # Set defaults for theme admonition icons
     admonition = set_default(icon, "admonition", {}, dict)
-    set_default(admonition, "note", None, str)
-    set_default(admonition, "abstract", None, str)
-    set_default(admonition, "info", None, str)
-    set_default(admonition, "tip", None, str)
-    set_default(admonition, "success", None, str)
-    set_default(admonition, "question", None, str)
-    set_default(admonition, "warning", None, str)
-    set_default(admonition, "failure", None, str)
-    set_default(admonition, "danger", None, str)
-    set_default(admonition, "bug", None, str)
-    set_default(admonition, "example", None, str)
-    set_default(admonition, "quote", None, str)
+    if isinstance(admonition, dict):
+        icon["admonition"] = {
+            key: value for key, value in admonition.items() if value is not None
+        }
 
     # Set defaults for theme palette settings and normalize to list
     palette = theme.setdefault("palette", [])


### PR DESCRIPTION
## Problem
Custom admonition types were **structurally impossible** to represent in core config because `theme.icon.admonition` was modeled as a fixed struct of built‑ins. That created a **closed set** at the schema level:

- Any user key like `theme.icon.admonition.todo` had nowhere to land in the typed model.
- Python defaults enumerated the same fixed keys, reinforcing the idea that only built‑ins mattered.

This prevented custom admonition types from flowing through the config → template → CSS pipeline, even though Markdown parsing supports arbitrary `!!! <type>`.

## Approach
- **Switch to a map** for admonition icons in Rust (`BTreeMap<String, String>`), matching the existing `tag` icon model.
- **Stop enumerating fixed admonition keys** in Python defaults; keep the dict and filter out `None` values so deserialization into `String` is clean.
- **Preserve backwards compatibility**: existing configs with built‑in keys still work (they’re just map entries).

## Files changed
- `crates/zensical/src/config/theme.rs`
- `python/zensical/config.py`

## Behavior changes
- Arbitrary admonition icons under `theme.icon.admonition.<type>` now reach template context intact.
- Defaults no longer imply a closed set of admonition types.

## Cross‑repo context
- **Companion UI PR (zensical/ui)**: https://github.com/zensical/ui/pull/42
  - Consumes these open‑ended keys and applies icon/color styling generically.

## Testing
- Manual smoke test with a config containing a custom admonition key (e.g. `todo`) to confirm parsing and template rendering do not fail.

## Scope notes
- This PR only opens the config surface. Styling (icon/color rendering) is handled in the UI template PR. Custom title registry is out of scope.
