### PR TITLE
feature: generate object inventory file (API symbols)

### DIFF
--- a/crates/zensical/src/workflow.rs
+++ b/crates/zensical/src/workflow.rs
@@ -25,6 +25,8 @@
 
 //! Workflow definitions
 
+use pyo3::types::PyAnyMethods;
+use pyo3::Python;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -48,8 +50,6 @@ use super::template::Template;
 mod cached;
 
 use cached::cached;
-use pyo3::types::PyAnyMethods;
-use pyo3::Python;
 
 // ----------------------------------------------------------------------------
 // Functions


### PR DESCRIPTION
The changes will only take effect once a new version of mkdocstrings is released (and users upgrade to it). With an older mkdocstrings version, users just won't get the inventory file (/objects.inv -> 404), and Zensical won't crash or emit warnings.