### PR TITLE
chore: release v0.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.16"
+version = "0.0.17"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version brings support for automatic and manual API cross-references. Symbol names on pages that include auto-generated API documentation now automatically link to the relevant section. Additionally, manual cross-references can be created both in Markdown pages and Python docstrings with the following syntax:

``` md
See [the FastAPI class][fastapi.FastAPI] for reference.
```

Moreover, cross-references from loaded inventories are now supported as well.

### Highlights

- Support for API cross-references
- Improve auto-reloading capabilities