### PR TITLE
chore: release v0.0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.17"
+version = "0.0.18"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version fixes a reload loop when mkdocstrings `paths` setting is set to `.`, which was introduced in 0.0.17 as a regression, and a race condition related to caching is resolved. Additionally, Zensical was too retrictive, only allowing specific meta keys for the navigation templates. This has been relaxed to allow any meta keys to be used.