### PR TITLE
chore: release v0.0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.18"
+version = "0.0.19"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds support for the generation of `objects.inv` for your [mkdocstrings]-powered documentation site, allowing external tools to discover and link to your API documentation. No changes to your configuration are necessary.

Please also update to mkdocstrings v1.0.2.

[mkdocstrings]: https://mkdocstrings.github.io/