### PR TITLE
Changed cache dir to .cache/zensical

### DIFF
--- a/crates/zensical/src/config.rs
+++ b/crates/zensical/src/config.rs
@@ -162,7 +162,7 @@ impl Config {
         path.pop();
 
         // Ensure directory exists
-        let path = path.join(".cache");
+        let path = path.join(".cache").join("zensical");
         fs::create_dir_all(&path)
             .and_then(|()| path.canonicalize())
             .inspect(|path| {


### PR DESCRIPTION
Hey, really small PR here. I noticed that Zensical writes directly to a project-level cache directory `./.cache`.

I think that's great, except that it is nice for multiple tools to be able to write to this directory: e.g. I like to `export RUFF_CACHE_DIR=".cache/ruff"` and similar.

Accordingly, I think it would be better for Zensical to write to `./.cache/zensical`. PR adjusts this!

After all, if you were to write to the user-level cache, you'd write to `$XDG_CACHE_HOME/zensical` and not `$XDG_CACHE_HOME`, right? Thanks!