### PR TITLE
refactor: retrieve autorefs once

### DIFF
--- a/crates/zensical/src/structure/markdown.rs
+++ b/crates/zensical/src/structure/markdown.rs
@@ -61,8 +61,6 @@ pub struct Markdown {
     pub title: String,
     /// Table of contents.
     pub toc: Vec<Section>,
-    /// Autorefs (mkdocstrings).
-    pub autorefs: Option<Autorefs>,
 }
 
 // ----------------------------------------------------------------------------
@@ -89,7 +87,6 @@ impl Markdown {
             content: markdown.content,
             search: markdown.search,
             toc: markdown.toc,
-            autorefs: markdown.autorefs,
         })
     }
 }

--- a/crates/zensical/src/structure/markdown/autorefs.rs
+++ b/crates/zensical/src/structure/markdown/autorefs.rs
@@ -434,22 +434,6 @@ impl Autorefs {
         ))
     }
 
-    /// Extends autorefs with another instance.
-    pub fn extend(&mut self, other: Autorefs) {
-        for (key, values) in other.primary {
-            self.primary.entry(key).or_default().extend(values);
-        }
-        for (key, values) in other.secondary {
-            self.secondary.entry(key).or_default().extend(values);
-        }
-        for (key, value) in other.inventory {
-            self.inventory.insert(key, value);
-        }
-        for (key, value) in other.titles {
-            self.titles.insert(key, value);
-        }
-    }
-
     /// Replaces autorefs in the given content.
     pub fn replace_in(&self, content: String, from_url: &str) -> String {
         let output = AUTOREF_RE.replace_all(&content, |captures: &Captures| {

--- a/crates/zensical/src/structure/page.rs
+++ b/crates/zensical/src/structure/page.rs
@@ -35,7 +35,6 @@ use zrx::id::Id;
 use zrx::scheduler::Value;
 
 use crate::config::Config;
-use crate::structure::markdown::Autorefs;
 use crate::template::{Template, GENERATOR};
 
 use super::dynamic::Dynamic;
@@ -77,8 +76,6 @@ pub struct Page {
     pub toc: Vec<Section>,
     /// Search index.
     pub search: Vec<SearchItem>,
-    /// Autorefs (mkdocstrings).
-    pub autorefs: Option<Autorefs>,
     /// Ancestor pages.
     pub ancestors: Vec<NavigationItem>,
     /// Previous page.
@@ -186,7 +183,6 @@ impl Page {
             content: markdown.content,
             toc: markdown.toc,
             search: markdown.search,
-            autorefs: markdown.autorefs,
             path: path.to_string_lossy().into_owned(),
             ancestors: Vec::new(),
             previous_page: None,

--- a/python/zensical/markdown.py
+++ b/python/zensical/markdown.py
@@ -154,24 +154,6 @@ def render(content: str, path: str, url: str) -> dict:
     if meta.get("search", {}).get("exclude", False):
         search_processor.data = []
 
-    # Extract URL map from extension if available
-    for extension in md.registeredExtensions:
-        if type(extension).__qualname__ == "MkdocstringsExtension":
-            autorefs = {
-                "primary": extension._autorefs._primary_url_map,  # type: ignore[attr-defined]
-                "secondary": extension._autorefs._secondary_url_map,  # type: ignore[attr-defined]
-                "inventory": extension._autorefs._abs_url_map,  # type: ignore[attr-defined]
-                "titles": extension._autorefs._title_map,  # type: ignore[attr-defined]
-            }
-            break
-    else:
-        autorefs = {
-            "primary": {},
-            "secondary": {},
-            "inventory": {},
-            "titles": {},
-        }
-
     # Return Markdown with metadata
     return {
         "meta": meta,
@@ -179,7 +161,6 @@ def render(content: str, path: str, url: str) -> dict:
         "search": search_processor.data,
         "title": "",
         "toc": [_convert_toc(item) for item in getattr(md, "toc_tokens", [])],
-        "autorefs": autorefs,
     }
 
 


### PR DESCRIPTION
Related: https://github.com/zensical/zensical/issues/98#issuecomment-3813379698

This change requires that users upgrade to mkdocstrings >= 1.0.2, which is already released (this was done for the previous release of Zensical).