### PR TITLE
chore: release v0.0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-watch"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
 zensical-serve = { version = "0.0.1", path = "crates/zensical-serve" }
-zensical-watch = { version = "0.0.1", path = "crates/zensical-watch" }
+zensical-watch = { version = "0.0.2", path = "crates/zensical-watch" }
 
 ahash = "0.8"
 base64 = "0.22"

--- a/crates/zensical-watch/Cargo.toml
+++ b/crates/zensical-watch/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-watch"
-version = "0.0.1"
+version = "0.0.2"
 description = "Resilient file watcher"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.19"
+version = "0.0.20"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version fixes excessive memory usage when building large mkdocstrings-powered documentation sites. Additionally, it fixes an issue where the build sometimes terminates prematurely. We're working on further improvements to memory consumption and stability in upcoming releases, as we're currently refactoring a significant part of the runtime.