### PR TITLE
chore: release v0.0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.20"
+version = "0.0.21"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version updates the [user interface] to [v0.0.6], which fixes excessive memory usage for pages with hundreds of links that are marked with data-preview (for instant previews), among several other improvements and bug fixes.

[user interface]: https://github.com/zensical/ui
[v0.0.6]: https://github.com/zensical/ui/releases/tag/v0.0.6

### Highlights

- Back-to-top button was moved to the bottom for `modern` theme
- Several fixes for instant previews, improving memory usage and usability.