### PR TITLE
feature: support autorefs plugin

### DIFF
--- a/crates/zensical/src/structure/nav.rs
+++ b/crates/zensical/src/structure/nav.rs
@@ -436,8 +436,10 @@ pub(crate) fn to_title(component: &str) -> String {
 
 fn get_autorefs() -> Autorefs {
     match Python::attach(|py| {
-        let module = py.import("mkdocstrings._internal.extension")?;
-        module.call_method0("_get_autorefs")?.extract::<Autorefs>()
+        let module = py.import("zensical.compat.autorefs")?;
+        module
+            .call_method0("get_autorefs_data")?
+            .extract::<Autorefs>()
     }) {
         Ok(autorefs) => autorefs,
         Err(_) => Autorefs::new(),

--- a/crates/zensical/src/workflow.rs
+++ b/crates/zensical/src/workflow.rs
@@ -253,8 +253,8 @@ pub fn generate_object_inventory(
     let config = config.clone();
     pages.map(move |_| {
         let data = Python::attach(|py| {
-            let module = py.import("mkdocstrings._internal.extension")?;
-            module.call_method0("_get_inventory")?.extract::<Vec<u8>>()
+            let module = py.import("zensical.compat.mkdocstrings")?;
+            module.call_method0("get_inventory")?.extract::<Vec<u8>>()
         });
 
         // Write object inventory to disk

--- a/python/zensical/compat/__init__.py
+++ b/python/zensical/compat/__init__.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025-2026 Zensical and contributors
+
+# SPDX-License-Identifier: MIT
+# All contributions are certified under the DCO
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.

--- a/python/zensical/compat/autorefs.py
+++ b/python/zensical/compat/autorefs.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2025-2026 Zensical and contributors
+
+# SPDX-License-Identifier: MIT
+# All contributions are certified under the DCO
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mkdocs_autorefs import AutorefsExtension
+
+
+# ----------------------------------------------------------------------------
+# Global variables
+# ----------------------------------------------------------------------------
+AUTOREFS: AutorefsPlugin | None = None
+
+
+# ----------------------------------------------------------------------------
+# Classes
+# ----------------------------------------------------------------------------
+class AutorefsPage:
+    """Mock MkDocs pages."""
+
+    def __init__(self, url: str, path: str):
+        self.url = url
+        self.path = path
+
+
+class AutorefsPlugin:
+    """Mock the autorefs plugin (data store)."""
+
+    def __init__(self) -> None:
+        self.current_page: AutorefsPage | None = None
+        self.scan_toc: bool = True
+        self.record_backlinks: bool = False
+
+        self._primary_url_map: dict[str, list[str]] = {}
+        self._secondary_url_map: dict[str, list[str]] = {}
+        self._abs_url_map: dict[str, str] = {}
+        self._title_map: dict[str, str] = {}
+
+    def register_anchor(
+        self,
+        page: AutorefsPage,
+        identifier: str,
+        anchor: str | None = None,
+        *,
+        title: str | None = None,
+        primary: bool = True,
+    ) -> None:
+        url = f"{page.url}#{anchor or identifier}"
+        url_map = self._primary_url_map if primary else self._secondary_url_map
+        if identifier in url_map:
+            if url not in url_map[identifier]:
+                url_map[identifier].append(url)
+        else:
+            url_map[identifier] = [url]
+        if title and url not in self._title_map:
+            self._title_map[url] = title
+
+    def register_url(self, identifier: str, url: str) -> None:
+        self._abs_url_map[identifier] = url
+
+
+# ----------------------------------------------------------------------------
+# Functions
+# ----------------------------------------------------------------------------
+def get_autorefs_plugin() -> AutorefsPlugin:
+    """Get the global autorefs instance."""
+    global AUTOREFS  # noqa: PLW0603
+    if AUTOREFS is None:
+        AUTOREFS = AutorefsPlugin()
+    return AUTOREFS
+
+
+def get_autorefs_extension() -> AutorefsExtension | None:
+    """Get the MkDocs Autorefs extension."""
+    try:
+        from mkdocs_autorefs import AutorefsExtension  # noqa: PLC0415
+    except ImportError:
+        return None
+    return AutorefsExtension(get_autorefs_plugin())  # type: ignore[arg-type,unused-ignore]
+
+
+def set_autorefs_page(url: str, path: str) -> None:
+    """Set the current page for autorefs."""
+    plugin = get_autorefs_plugin()
+    plugin.current_page = AutorefsPage(url=url, path=path)
+
+
+def get_autorefs_data() -> dict[str, Any]:
+    """Get autorefs data.
+
+    This function is called from Rust to replace the `<autoref>`
+    elements written in the HTML output by both the autorefs
+    Markdown extension (for manual cross-references) and the
+    mkdocstrings extension (for automatic cross-references).
+    """
+    if AUTOREFS:
+        return {
+            "primary": AUTOREFS._primary_url_map,
+            "secondary": AUTOREFS._secondary_url_map,
+            "inventory": AUTOREFS._abs_url_map,
+            "titles": AUTOREFS._title_map,
+        }
+    return {}
+
+
+def reset() -> None:
+    """Reset global state in-between rebuilds."""
+    global AUTOREFS  # noqa: PLW0603
+    AUTOREFS = None

--- a/python/zensical/compat/mkdocstrings.py
+++ b/python/zensical/compat/mkdocstrings.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2025-2026 Zensical and contributors
+
+# SPDX-License-Identifier: MIT
+# All contributions are certified under the DCO
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from __future__ import annotations
+
+from typing import Any
+
+from mkdocstrings import Handlers, MkdocstringsExtension
+
+from zensical.compat.autorefs import get_autorefs_plugin
+
+# ----------------------------------------------------------------------------
+# Global variables
+# ----------------------------------------------------------------------------
+HANDLERS: Handlers | None = None
+
+
+# ----------------------------------------------------------------------------
+# Classes
+# ----------------------------------------------------------------------------
+class ToolConfig:
+    """Mock mkdocstrings tooling configuration."""
+
+    def __init__(self, config_file_path: str | None = None) -> None:
+        self.config_file_path = config_file_path
+
+
+# ----------------------------------------------------------------------------
+# Functions
+# ----------------------------------------------------------------------------
+def get_mkdocstrings_extension(
+    config: dict[str, Any],
+    path: str,
+) -> MkdocstringsExtension:
+    """Create the mkdocstrings Markdown extension."""
+    autorefs = get_autorefs_plugin()
+
+    global HANDLERS  # noqa: PLW0603
+    if HANDLERS is None:
+        mkdocstrings_config = config["plugins"]["mkdocstrings"]["config"]
+        tool_config = ToolConfig(config_file_path=path)
+        HANDLERS = Handlers(
+            theme="material",
+            default=mkdocstrings_config.get("default_handler") or "python",
+            inventory_project=mkdocstrings_config.get("inventory_project")
+            or config["site_name"],
+            inventory_version=mkdocstrings_config.get("inventory_version"),
+            handlers_config=mkdocstrings_config.get("handlers"),
+            custom_templates=mkdocstrings_config.get("custom_templates"),
+            mdx=config["markdown_extensions"],
+            mdx_config=config["mdx_configs"],
+            locale=mkdocstrings_config.get("locale"),
+            tool_config=tool_config,
+        )
+
+        HANDLERS._download_inventories()
+        url_map = autorefs._abs_url_map
+        for identifier, url in HANDLERS._yield_inventory_items():
+            url_map[identifier] = url
+
+    return MkdocstringsExtension(handlers=HANDLERS, autorefs=autorefs)
+
+
+def get_inventory() -> bytes:
+    """Get the objects.inv inventory as bytes.
+
+    This function is called from Rust to write
+    the objects.inv file in the site directory.
+    """
+    if HANDLERS:
+        return HANDLERS.inventory.format_sphinx()
+    return b""
+
+
+def reset() -> None:
+    """Reset global state in-between rebuilds."""
+    global HANDLERS  # noqa: PLW0603
+    HANDLERS = None

--- a/python/zensical/markdown.py
+++ b/python/zensical/markdown.py
@@ -28,11 +28,10 @@ from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from markdown import Extension as MarkdownExtension
 from markdown import Markdown
-from markdown.preprocessors import Preprocessor
 from yaml import SafeLoader
 
+from zensical.compat.autorefs import set_autorefs_page
 from zensical.config import get_config
 from zensical.extensions.links import LinksExtension
 from zensical.extensions.search import SearchExtension
@@ -55,39 +54,6 @@ Regex pattern to extract front matter.
 
 
 # ----------------------------------------------------------------------------
-# Classes
-# ----------------------------------------------------------------------------
-
-
-class CurrentPageData(Preprocessor):
-    """Preprocessor to store current page URL and path."""
-
-    def __init__(self, md: Markdown, url: str, path: str):
-        super().__init__(md)
-        self.url = url
-        self.path = path
-
-    def run(self, lines: list[str]) -> list[str]:
-        return lines
-
-
-class CurrentPageExtension(MarkdownExtension):
-    """Markdown extension to store current page URL and path."""
-
-    def __init__(self, url: str, path: str):
-        super().__init__()
-        self.url = url
-        self.path = path
-
-    def extendMarkdown(self, md: Markdown) -> None:  # noqa: N802
-        md.preprocessors.register(
-            CurrentPageData(md, self.url, self.path),
-            "zensical_current_page",
-            0,
-        )
-
-
-# ----------------------------------------------------------------------------
 # Functions
 # ----------------------------------------------------------------------------
 
@@ -102,14 +68,11 @@ def render(content: str, path: str, url: str) -> dict:
     """
     config = get_config()
 
-    # Insert current page extension at the beginning
-    extensions = [CurrentPageExtension(url, path)] + config[
-        "markdown_extensions"
-    ]
+    set_autorefs_page(url, path)
 
     # Initialize Markdown parser
     md = Markdown(
-        extensions=extensions,
+        extensions=config["markdown_extensions"],
         extension_configs=config["mdx_configs"],
     )
 


### PR DESCRIPTION
This PR brings support for using autorefs without mkdocstrings.

In order to support that, we incorporate Zensical-related from mkdocstrings within our code base, for better control (and much more elegant logic).

Before, mkdocstrings would expose a Markdown extension as "mkdocstrings", that Zensical would add (as a string) to its configured Markdown extensions list when detecting the plugin. Now, Zensical instantiates the extension itself (which simplifies things a lot since we don't have to synchronize releases -and therefore code!- of Zensical and mkdocstrings).

Instead of having several possible sources for autorefs data (mkdocstrings and autorefs itself), we use a global data store that both autorefs and mkdocstrings reuse to register data. Zensical can simply retrieve this data when ready, with a `call_method0` Pyo3 call (like before).

We instantiate the autorefs Markdown extension ourselves too, while mocking the classes used by mkdocstrings (autorefs plugin, MkDocs pages) to provide the same interface. What's nice about this is that we can now set the current page being rendered in autorefs without having to inject a dummy Markdown processor (that would before just act as a data store, for mkdocstrings to retrieve the current page and set it on the autorefs plugin instance). Since we control the (mocked) plugin, we can easily change its current page attribute.

This change effectively decouples Zensical from mkdocstrings, which means users upgrading Zensical don't even have to upgrade mkdocstrings (and I don't even have to release a new version of mkdocstrings, even though I could, later of course, just to clean up).

> [!WARNING]
> I have to release a new version of mkdocs-autorefs before we release a new version of Zensical. Let me make sure it still works perfectly with the hook-to-processor move.