### PR TITLE
fix: don't watch mkdocstrings-configured path if it's the root directory

### DIFF
--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -501,7 +501,7 @@ def _list_sources(config: dict, config_file: str) -> list[tuple[str, int]]:
     root = Path(config_file).parent.resolve()
     for python_path in python_paths:
         path = root.joinpath(python_path).resolve()
-        if path.is_dir() and path.is_relative_to(root):
+        if path.is_dir() and path.is_relative_to(root) and path != root:
             for subpath in path.rglob("*"):
                 # Path.rglob can't do patterns, so we need to filter here
                 if subpath.suffix in {


### PR DESCRIPTION
This is a follow-up of commit 6e3d5ef64b4c7ddf882a43bebab6b5293c120a18 which was actually incomplete. Since a/ is relative to a/, we also have to check that a path configured through mkdocstrings-python's  option isn't the project root itself.