### PR TITLE
fix: reset global data in compatibility modules between each rebuild

### DIFF
--- a/crates/zensical/src/config.rs
+++ b/crates/zensical/src/config.rs
@@ -81,6 +81,12 @@ impl Config {
     {
         let path = path.as_ref();
         Python::attach(|py| {
+            // Reset global data in compatibility modules
+            py.import("zensical.compat.autorefs")?
+                .call_method0("reset")?;
+            py.import("zensical.compat.mkdocstrings")?
+                .call_method0("reset")?;
+
             // Configuration is parsed in Python, since we must support certain
             // YAML tags like `!ENV`, and allow to reference Python functions
             // in configuration. For TOML, this is technically not necessary,


### PR DESCRIPTION
Without resetting mkdocstrings' data, updating a source file would trigger a reload, but mkdocstrings wouldn't collect the data again, so the rendered/served HTML would stay unchanged.

For correctness, we also reset autorefs' data, to make sure old items don't persist in the object inventory, or now broken cross-references don't resolve to actual locations, things like that.

Not sure about the **fix** type, let me know if you think **refactor** would be better :thinking: 