### PR TITLE
chore: release v0.0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.21"
+version = "0.0.22"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.21"
+version = "0.0.22"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds support for the [autorefs] plugin, and further improves performance for large mkdocstrings projects. The [user interface] is updated to [v0.0.7], which fixes some isses with the mobile browsering experience.

[autorefs]: https://github.com/mkdocstrings/autorefs
[user interface]: https://github.com/zensical/ui
[v0.0.7]: https://github.com/zensical/ui/releases/tag/v0.0.7