### PR TITLE
chore: release v0.0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.22"
+version = "0.0.23"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
# Summary

This version fixes a regression introduced in 0.0.22, where builds would error with mkdocstrings being not found, although the plugin wasn't configured.