### PR TITLE
Livereload - https websocket

### DIFF
--- a/crates/zensical/src/config/project.rs
+++ b/crates/zensical/src/config/project.rs
@@ -61,6 +61,8 @@ pub struct Project {
     pub use_directory_urls: bool,
     /// Development server address.
     pub dev_addr: String,
+    /// Development WebSocket path.
+    pub dev_ws: Option<String>,
     /// Copyright notice.
     pub copyright: Option<String>,
     /// Repository URL.

--- a/crates/zensical/src/server.rs
+++ b/crates/zensical/src/server.rs
@@ -74,13 +74,14 @@ pub fn create_server(
 
     // Create new thread to run the server
     let base = config.get_base_path();
+    let dev_ws_path = config.project.dev_ws.clone();
     thread::spawn({
         let tx = tx.clone();
         move || -> Result {
             // Ensure site directory exists
             fs::create_dir_all(&site_dir).unwrap();
             let stack = Stack::new()
-                .with(Client::default())
+                .with(Client::new(dev_ws_path))
                 .with(middleware::WebSocketHandshake::default())
                 .with(middleware::NormalizePath::default())
                 .with(middleware::BasePath::new(base).expect("invariant"))

--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -161,6 +161,7 @@ def _apply_defaults(config: dict, path: str) -> dict:
     set_default(config, "site_author", None, str)
     set_default(config, "use_directory_urls", True, bool)
     set_default(config, "dev_addr", "localhost:8000", str)
+    set_default(config, "dev_ws", None, str)
     set_default(config, "copyright", None, str)
 
     # Set defaults for repository settings


### PR DESCRIPTION
I had to have zensical servebehind a web-proxy for rapid iteration with others and noticed the livereload wasn't working, since even the test sites are behind https

This PR does two updates:

1. for my initial case, allow the websocket to be ws or wss by checking location.protocol
2. my dev server was actually behind a /dev path, so I needed a custom websocket path

I tried my best to have the ws variable with the smallest set of changes (it has been a while since I have done anything in rust)