### PR TITLE
chore: split Documentation workflow into two separate jobs

### DIFF
--- a/python/zensical/bootstrap/.github/workflows/docs.yml
+++ b/python/zensical/bootstrap/.github/workflows/docs.yml
@@ -1,29 +1,54 @@
 name: Documentation
+
 on:
   push:
     branches:
       - master
       - main
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+
 jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install zensical
+
+      - name: Build Documentation
+        run: zensical build --clean
+
+      - name: Upload Documentation
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
   deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
     steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: pip install zensical
-      - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@v4
-        with:
-          path: site
-      - uses: actions/deploy-pages@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy Documentation
         id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Split single deployment job into `build` and `deploy`
- Bump GitHub Actions versions:
  - actions/checkout: v5 → v6
  - actions/setup-python: v5 → v6
- Add descriptive names to steps