### PR TITLE
fix: same page links '.' with directory URLs disabled (regression) (#389)

### DIFF
--- a/crates/zensical/src/template/filter.rs
+++ b/crates/zensical/src/template/filter.rs
@@ -74,7 +74,7 @@ pub fn url_filter(state: &State, url: String) -> String {
         }
 
         // We can return if we don't stay on the same page
-        if relative_url != "." {
+        if relative_url != "./." {
             return relative_url;
         }
 


### PR DESCRIPTION
This issue was initially fixed in https://github.com/zensical/zensical/commit/924b3ffd8a101d84a9abdb193f1e44c7c85ad4ef, and then broke with https://github.com/zensical/zensical/commit/e3fc49f72fb299f467557edabda6a004c84597fd which didn't update the relevant part of the code (`.` -> `./.`).

Tested with both directory URLs and non-directory URLs, behaved correctly :+1: 