### PR TITLE
chore: release v0.0.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.23"
+version = "0.0.24"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.23"
+version = "0.0.24"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version updates the [user interface] to [v0.0.8], which fixes issues with instant previews for Chinese and other non-ASCII languages, and layout shifts when switching from short to long pages in the modern theme. Additionally, same-page links for when directory URLs are disabled where not resolved correctly, which is fixed as well.

[user interface]: https://github.com/zensical/ui
[v0.0.8]: https://github.com/zensical/ui/releases/tag/v0.0.8