### PR TITLE
Fix `zensical.toml` typos

### DIFF
--- a/python/zensical/bootstrap/zensical.toml
+++ b/python/zensical/bootstrap/zensical.toml
@@ -280,7 +280,7 @@ features = [
 
 # ----------------------------------------------------------------------------
 # In the "palette" subsection you can configure options for the color scheme.
-# You can configure different color # schemes, e.g., to turn on dark mode,
+# You can configure different color schemes, e.g., to turn on dark mode,
 # that the user can switch between. Each color scheme can be further
 # customized.
 #


### PR DESCRIPTION
Fixes typos in the `zensical.toml` configuration file.

* Remove random # in a comment
* Correct spelling for "different"