### PR TITLE
fix: keep development server alive on config errors during serve

### DIFF
--- a/crates/zensical/src/lib.rs
+++ b/crates/zensical/src/lib.rs
@@ -35,6 +35,7 @@ use pyo3::prelude::*;
 use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, Instant};
+use zensical_watch::{Agent, Error as WatchError};
 use zrx::scheduler::action::Report;
 use zrx::scheduler::Scheduler;
 
@@ -221,6 +222,42 @@ fn build(py: Python, config_file: PathBuf, clean: bool) -> PyResult<()> {
     })
 }
 
+/// Watches the configuration file until it changes or the user interrupts.
+///
+/// Returns `true` if the configuration file was modified (should retry the
+/// build), or `false` if the user interrupted the process.
+fn watch_config_until_change(config_file: &PathBuf) -> PyResult<bool> {
+    // Canonicalize so the path matches canonicalized paths from the watcher
+    let config_path = std::fs::canonicalize(config_file)
+        .unwrap_or_else(|_| config_file.clone());
+
+    let agent = Agent::new(Duration::from_millis(20), move |res| {
+        if let Ok(event) = res {
+            if *event.path() == config_path {
+                return Err(WatchError::Disconnected);
+            }
+        }
+        Ok(())
+    });
+
+    // Watch the config file; if watching fails just return true so the outer
+    // loop retries (it will either succeed or fail with a proper error)
+    if agent.watch(config_file).is_err() {
+        return Ok(true);
+    }
+
+    loop {
+        thread::sleep(Duration::from_millis(100));
+        if agent.is_terminated() {
+            return Ok(true);
+        }
+        if Python::attach(|py| py.check_signals().is_err()) {
+            println!("Received interrupt, exiting");
+            return Ok(false);
+        }
+    }
+}
+
 /// Builds and serves the project.
 #[pyfunction]
 fn serve(
@@ -232,6 +269,21 @@ fn serve(
             Ok(true) => {
                 options.open = false;
                 seq += 1;
+            }
+            // After the first successful build, handle config errors gracefully
+            // by printing a warning and waiting for the config to be fixed,
+            // instead of killing the development server
+            Err(err) if seq > 0 => {
+                let msg = Python::attach(|py| format!("{}", err.value(py)));
+                eprintln!(
+                    "Warning: Configuration error in {}: {}. \
+                     Falling back to last valid configuration.",
+                    config_file.display(),
+                    msg
+                );
+                if !watch_config_until_change(&config_file)? {
+                    return Ok(());
+                }
             }
             other => return other.map(|_| ()),
         }

--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -91,8 +91,11 @@ def parse_config(path: str) -> dict:
 def parse_zensical_config(path: str) -> dict:
     """Parse zensical.toml configuration file."""
     global _CONFIG  # noqa: PLW0603
-    with open(path, "rb") as f:
-        config = tomllib.load(f)
+    try:
+        with open(path, "rb") as f:
+            config = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ConfigurationError(str(e)) from e
     if "project" in config:
         config = config["project"]
 


### PR DESCRIPTION
## Summary

Fixes #403

When `zensical serve` is running and `zensical.toml` is saved mid-edit (causing a syntax error or invalid settings), the development server no longer crashes. Instead it:

- Prints a warning to stderr with the config error details
- Watches the config file for the next save
- Automatically resumes and rebuilds once the file is valid again

The original behavior is preserved for the initial startup: if the config is invalid on first launch, the server exits immediately.

This matches the behavior described in MkDocs (as noted in the issue comments).

## Changes

- **`crates/zensical/src/lib.rs`**: Added `watch_config_until_change()` helper that watches the config file until it is modified or the user interrupts. Modified `serve()` to catch config errors on non-first runs (`seq > 0`) and call this helper instead of propagating the error.
- **`python/zensical/config.py`**: Wrapped `tomllib.load()` in a try/except to convert raw `TOMLDecodeError` into a `ConfigurationError`, giving a cleaner, consistent error message.