### PR TITLE
fix: replace deprecated codecs.open() with built-in open() (#429)

### DIFF
--- a/python/zensical/extensions/emoji.py
+++ b/python/zensical/extensions/emoji.py
@@ -23,7 +23,6 @@
 
 from __future__ import annotations
 
-import codecs
 import functools
 import os
 from glob import iglob
@@ -80,7 +79,7 @@ def to_svg(
 @functools.cache
 def _load(file: str) -> str:
     """Load icon from file."""
-    with codecs.open(file, encoding="utf-8") as f:
+    with open(file, encoding="utf-8") as f:
         return f.read()
 
 


### PR DESCRIPTION
## Summary

Replace `codecs.open()` with the built-in `open()` in `python/zensical/extensions/emoji.py` to resolve a `DeprecationWarning` on Python 3.14+.

- Resolves #429

## Background

`codecs.open()` was deprecated in **CPython 3.14** ([python/cpython#133036](https://github.com/python/cpython/issues/133036), [python/cpython#133038](https://github.com/python/cpython/pull/133038)). The built-in `open()` with `encoding` parameter is the official replacement, available since Python 3.0 — safe for the full supported range (`>=3.10`).

See also:
- [What's New in Python 3.14 — New Deprecations > codecs](https://docs.python.org/3/whatsnew/3.14.html)
- [Discussion: Deprecating codecs.open?](https://discuss.python.org/t/deprecating-codecs-open/88135)

## Changes

| File | Change |
|------|--------|
| `python/zensical/extensions/emoji.py` | `codecs.open(file, encoding="utf-8")` → `open(file, encoding="utf-8")`, remove unused `import codecs` |

## Notes

- `open()` returns `TextIOWrapper` (C impl) vs `codecs.open()` returning `StreamReaderWriter` (pure Python) — functionally identical for UTF-8 text reading, marginally faster
- No behavioral change for Python 3.10–3.13 users; suppresses `DeprecationWarning` for Python 3.14+ users
- Other projects have made the same change: e.g., [GRASS GIS (OSGeo/grass#7062)](https://github.com/OSGeo/grass/issues/7062)

## AI disclosure

This PR was created with the assistance of [Claude Code](https://claude.ai/claude-code). The change has been thoroughly reviewed and fully understood by the author — it is a straightforward 1:1 replacement of `codecs.open()` with the built-in `open()`, as officially recommended by CPython ([python/cpython#133036](https://github.com/python/cpython/issues/133036)). The author takes full responsibility for the correctness of this contribution.