### PR TITLE
chore: release v0.0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.25"
+version = "0.0.26"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
# Summary

This version fixes a regression introduced in 0.0.25 where the wheels built for manylinux x86 would be based on Python 3.8 instead of Python 3.10, making Zensical unusable on those architectures. This is related to a [recent bug] in our upstream dependency [maturin], which was introduced in version 1.12.5. Additionally, it fixes a deprecation warning on Python 3.14 when using the emoji extension.

[recent bug]: https://github.com/PyO3/maturin/issues/3059
[maturin]: https://github.com/PyO3/maturin