### PR TITLE
fix: skip queuing redundant watch paths (#434)

### DIFF
--- a/crates/zensical-watch/src/agent/handler.rs
+++ b/crates/zensical-watch/src/agent/handler.rs
@@ -100,13 +100,17 @@ impl Handler {
             recv(self.receiver) -> message => {
                 let res = match message? {
                     Action::Watch(path) => {
-                        self.monitor.watch(&path).map(|_| {
-                            self.queue.push(path);
+                        self.monitor.watch(&path).map(|changed| {
+                            if changed {
+                                self.queue.push(path);
+                            }
                         })
                     },
                     Action::Unwatch(path) => {
-                        self.monitor.unwatch(&path).map(|_| {
-                            self.queue.push(path);
+                        self.monitor.unwatch(&path).map(|changed| {
+                            if changed {
+                                self.queue.push(path);
+                            }
                         })
                     },
                 };


### PR DESCRIPTION
I confirmed locally that this fix resolves the issue with mkdocstrings-python's `paths` and auto-appended snippets being under the `docs/` folder. I'll let you check if the changes make sense (it might have an impact I'm not seeing) @squidfunk :slightly_smiling_face: 