### PR TITLE
chore: release v0.0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-watch"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
 zensical-serve = { version = "0.0.1", path = "crates/zensical-serve" }
-zensical-watch = { version = "0.0.2", path = "crates/zensical-watch" }
+zensical-watch = { version = "0.0.3", path = "crates/zensical-watch" }
 
 ahash = "0.8"
 base64 = "0.22"

--- a/crates/zensical-watch/Cargo.toml
+++ b/crates/zensical-watch/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-watch"
-version = "0.0.2"
+version = "0.0.3"
 description = "Resilient file watcher"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.26"
+version = "0.0.27"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version fixes a reload loop for when auto-appended snippets are located inside of the `docs` directory, and auto-reload for pages with Chinese path segments.