### PR TITLE
Inject front matter into Markdown instance for macros extension

### DIFF
--- a/python/zensical/markdown.py
+++ b/python/zensical/markdown.py
@@ -101,7 +101,6 @@ def render(content: str, path: str, url: str) -> dict:
         except Exception:  # noqa: BLE001
             pass
 
-
     # Inject meta into the Markdown instance for extension compatibility
     md.front_matter = meta
     # Optionally set md.Meta for Python-Markdown compatibility (list-of-strings values)

--- a/python/zensical/markdown.py
+++ b/python/zensical/markdown.py
@@ -101,6 +101,21 @@ def render(content: str, path: str, url: str) -> dict:
         except Exception:  # noqa: BLE001
             pass
 
+
+    # Inject meta into the Markdown instance for extension compatibility
+    md.front_matter = meta
+    # Optionally set md.Meta for Python-Markdown compatibility (list-of-strings values)
+    if not hasattr(md, "Meta") or md.Meta is None:
+        md.Meta = {}
+    for k, v in meta.items():
+        # Python-Markdown Meta extension expects list-of-strings
+        if isinstance(v, list):
+            md.Meta[k] = [str(i) for i in v]
+        elif v is not None:
+            md.Meta[k] = [str(v)]
+        else:
+            md.Meta[k] = []
+
     # Convert Markdown and set nullish metadata to empty string, since we
     # currently don't have a null value for metadata in the Rust runtime
     content = md.convert(content)


### PR DESCRIPTION
**Summary:** 

This PR ensures that YAML front matter parsed from Markdown files is injected into the `Markdown` instance as both `md.front_matter` (full parsed dict) and `md.Meta` (Python-Markdown style, list-of-strings values) before calling `md.convert()`. This improves compatibility with Python-Markdown extensions (such as markdown-macros) that expect front matter to be available on the Markdown instance.

**Details:**
- Sets `md.front_matter = meta` for downstream extension access.
- Populates `md.Meta` for compatibility with extensions expecting the Python-Markdown Meta format.
- No change to the returned API; only the Markdown instance is updated during rendering.

**Motivation:**  

Previously, Zensical parsed front matter but did not expose it to Markdown extensions, requiring monkeypatches in downstream tools. This change allows extensions to access front matter natively, enabling better interoperability and reducing the need for workarounds.

**Related Issues:**
- Enables removal of monkeypatches in projects like [markdown-macros](https://github.com/barcar/markdown-macros).
- Fixes compatibility for any extension relying on front matter metadata.

**Testing:**
- Confirmed that Markdown extensions can now access `md.front_matter` and `md.Meta` as expected during the pipeline.

---