### PR TITLE
fix: equation rendering in code annotations

### DIFF
--- a/python/zensical/bootstrap/docs/index.md
+++ b/python/zensical/bootstrap/docs/index.md
@@ -35,7 +35,7 @@ For full documentation visit [zensical.org](https://zensical.org/docs/).
 > Go to [documentation](https://zensical.org/docs/authoring/admonitions/#collapsible-blocks)
 
 ??? info "Click to expand for more info"
-    
+
     This content is hidden until you click to expand it.
     Great for FAQs or long explanations.
 
@@ -132,7 +132,7 @@ $$
     to configure it on all your pages if they are more Maths-heavy than these
     simple starter pages.
 
-<script id="MathJax-script" async src="https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js"></script>
+<script id="MathJax-script" src="https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js"></script>
 <script>
   window.MathJax = {
     tex: {
@@ -146,6 +146,13 @@ $$
       processHtmlClass: "arithmatex"
     }
   };
+
+  document$.subscribe(() => {
+    MathJax.startup.output.clearCache()
+    MathJax.typesetClear()
+    MathJax.texReset()
+    MathJax.typesetPromise()
+  })
 </script>
 
 ## Task Lists


### PR DESCRIPTION
Fixing https://github.com/zensical/ui/issues/93#issuecomment-4089541461 by removing the `async` attribute and adding missing JS code.