### PR TITLE
chore: release v0.0.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1458,7 +1458,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-watch"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
 zensical-serve = { version = "0.0.1", path = "crates/zensical-serve" }
-zensical-watch = { version = "0.0.3", path = "crates/zensical-watch" }
+zensical-watch = { version = "0.0.4", path = "crates/zensical-watch" }
 
 ahash = "0.8"
 base64 = "0.22"

--- a/crates/zensical-watch/Cargo.toml
+++ b/crates/zensical-watch/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-watch"
-version = "0.0.3"
+version = "0.0.4"
 description = "Resilient file watcher"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.27"
+version = "0.0.28"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version updates the [user interface] to [v0.0.10], which fixes a couple of bugs related to search and code annotation rendering. Additionally, it adds support for version selectors in the modern theme, paving the way for adding support for [mike] to manage multiple versions of documentation on GitHub Pages.

In addition, this release adds new configuration options for the file watcher to improve compatibility in certain environments.

### File watcher

You can now opt into using a **polling-based file watcher**, which is particularly useful when running Docker on Windows, where filesystem event limitations (e.g., inotify constraints) can cause issues.

To enable the polling watcher:

``` bash
export ZENSICAL_POLL_WATCHER=1
```

The polling interval is configurable and defaults to `500` milliseconds (aligned with MkDocs behavior):

``` bash
export ZENSICAL_POLL_INTERVAL=500
```

[user interface]: https://github.com/zensical/ui
[v0.0.10]: https://github.com/zensical/ui/releases/tag/v0.0.10
[mike]: https://github.com/jimporter/mike