### PR TITLE
fix: leave absolute links untouched (#466)

### DIFF
--- a/python/zensical/extensions/links.py
+++ b/python/zensical/extensions/links.py
@@ -74,7 +74,7 @@ class LinksProcessor(Treeprocessor):
 
             # Parse URL and skip everything that is not a relative link
             url = urlparse(value)
-            if url.scheme or url.netloc:
+            if url.scheme or url.netloc or url.path.startswith("/"):
                 continue
 
             # Leave anchors that go to the same page as they are


### PR DESCRIPTION
Issue #466.

We match MkDocs' behavior by leaving absolute links untouched (no scheme, no netloc but starting with /). We do not prepend the configured site URL to these links, as users might rely on this behavior.