### PR TITLE
chore: release v0.0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.29"
+version = "0.0.30"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.29"
+version = "0.0.30"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds support for [mike], a tool for managing multiple versions of MkDocs projects on GitHub Pages. We created [a tailored fork of mike] for Zensical – all mike commands should work as expected. See the [mike documentation] for usage instructions.

Note that this is a temporary solution. Zensical will ship [native support for versioning] in the near future, which will remove the GitHub Pages constraint and offer more flexibility in how versions are deployed and served.

The [user interface] is updated to [v0.0.11], which adds a floating table of contents for mobile to the modern theme. The toggle sits at the bottom of the screen for easy thumb access, and the sidebar scrolls to accommodate arbitrarily long tables of contents. This release also includes several improvements: snappier sidebar animations, better tooltip readability, and improved inline code block sizing.

[mike]: https://github.com/jimporter/mike
[a tailored fork of mike]: https://github.com/squidfunk/mike
[native support for versioning]: https://zensical.org/about/roadmap/#versioning
[mike documentation]: https://github.com/jimporter/mike#readme
[user interface]: https://github.com/zensical/ui
[v0.0.11]: https://github.com/zensical/ui/releases/tag/v0.0.11