### PR TITLE
chore: release v0.0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.30"
+version = "0.0.31"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.30"
+version = "0.0.31"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version updates the [user interface] to [v0.0.12], which includes the [removal of 19 brand icons] due to the update of Lucide to v1, and the addition of 166 new icons, most of them in SimpleIcons and FontAwesome. Additionally, there are bug fixes related to the latest changes of the table of contents in the modern theme and instant navigation on anchor links.

[user interface]: https://github.com/zensical/ui
[v0.0.12]: https://github.com/zensical/ui/releases/tag/v0.0.12
[removal of 19 brand icons]: https://lucide.dev/guide/version-1