### PR TITLE
fix: only collect markdown pages in docs directory (#490)

### DIFF
--- a/crates/zensical/src/workflow.rs
+++ b/crates/zensical/src/workflow.rs
@@ -137,8 +137,13 @@ fn copy_file(
 pub fn process_markdown(
     config: &Config, files: &Stream<Id, String>,
 ) -> Stream<Id, Markdown> {
-    let matcher =
-        Arc::new(Matcher::from_str("zrs:::::**/*.md:").expect("invariant"));
+    let matcher = Arc::new(
+        Matcher::from_str(&format!(
+            "zrs::::{}:**/*.md:",
+            config.project.docs_dir
+        ))
+        .expect("invariant"),
+    );
 
     // Create pipeline to render Markdown files
     let config = config.clone();


### PR DESCRIPTION
Issue #490

Files ending with `.md` would previously be collected as Markdown pages even though they aren't in the docs directory. That includes files in the root folder, or any subfolder.

I am not sure this is the right fix: it works, but maybe the right fix is elsewhere in the chain (in the collected *files*?).