### PR TITLE
chore: release v0.0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.31"
+version = "0.0.32"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-serve"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "base64",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-zensical-serve = { version = "0.0.1", path = "crates/zensical-serve" }
+zensical-serve = { version = "0.0.2", path = "crates/zensical-serve" }
 zensical-watch = { version = "0.0.4", path = "crates/zensical-watch" }
 
 ahash = "0.8"

--- a/crates/zensical-serve/Cargo.toml
+++ b/crates/zensical-serve/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-serve"
-version = "0.0.1"
+version = "0.0.2"
 description = "HTTP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.31"
+version = "0.0.32"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version fixes a bug where Markdown files used as snippets were included into auto-generated navigation, and a bug with prefix stripping when the site URL contains a path component. Additionally, the Pygments dependency was updated to mitigate a vulnerability.