### PR TITLE
feature: switch container image to alpine for gitlab ci compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@
 
 # -----------------------------------------------------------------------------
 
-FROM python:3.14-alpine3.23 AS build
+FROM python:3.14-alpine3.23 AS base
+
+FROM base AS build
 
 # Disable bytecode caching during build
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -84,7 +86,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # -----------------------------------------------------------------------------
 
-FROM python:3.14-alpine3.23 AS image
+FROM base AS image
 
 # Add libgcc to allow running Rust extensions
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,15 +50,30 @@ COPY scripts scripts
 RUN mkdir -p python/zensical
 RUN python scripts/prepare.py
 
+# Create a stub project, which will allow us to install dependencies and have
+# them properly cached while changes to sources won't invalidate the cache
+RUN mkdir crates
+RUN cargo new --lib crates/zensical
+RUN cargo add pyo3 \
+    --manifest-path crates/zensical/Cargo.toml \
+    --features extension-module
+
+# Copy files to install dependencies - these will get installed into a virtual
+# environment, which is fine, since uv can later reuse the cached versions
+COPY pyproject.toml pyproject.toml
+COPY README.md README.md
+COPY uv.lock uv.lock
+
+# Install dependencies
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --dev --no-install-project
+
 # Copy files to build project
 COPY LICENSE.md LICENSE.md
 COPY crates crates
 COPY python python
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml
-COPY pyproject.toml pyproject.toml
-COPY README.md README.md
-COPY uv.lock uv.lock
 
 # Build wheel
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM python:3.14-alpine3.23 AS image
 
+# Add libgcc to allow running Rust extensions
 RUN apk add --no-cache \
     libgcc \
     tini

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,52 +50,35 @@ COPY scripts scripts
 RUN mkdir -p python/zensical
 RUN python scripts/prepare.py
 
-# Create a stub project, which will allow us to install dependencies and have
-# them properly cached while changes to sources won't invalidate the cache
-RUN mkdir crates
-RUN cargo new --lib crates/zensical
-RUN cargo add pyo3 \
-    --manifest-path crates/zensical/Cargo.toml \
-    --features extension-module
-
-# Copy files to install dependencies - these will get installed into a virtual
-# environment, which is fine, since uv can later reuse the cached versions
-COPY pyproject.toml pyproject.toml
-COPY README.md README.md
-COPY uv.lock uv.lock
-
-# Install dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --dev --no-install-project
-
-# Install additional dependencies
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system mkdocstrings-python
-
 # Copy files to build project
+COPY LICENSE.md LICENSE.md
 COPY crates crates
 COPY python python
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml
+COPY pyproject.toml pyproject.toml
+COPY README.md README.md
+COPY uv.lock uv.lock
 
-# Build project
-RUN . /.venv/bin/activate
+# Build wheel
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=target \
-    uv pip install --system . -v
+    uv build --wheel --out-dir /dist
 
 # -----------------------------------------------------------------------------
 
-FROM scratch AS image
+FROM python:3.14-alpine3.23 AS image
 
-# Copy relevant files from build
-COPY --from=build /bin/sh /bin/sh
-COPY --from=build /sbin/tini /sbin/tini
-COPY --from=build /lib /lib
-COPY --from=build /usr/lib /usr/lib
-COPY --from=build /usr/local /usr/local
+RUN apk add --no-cache \
+    libgcc \
+    tini
+
+# Install project and runtime dependency extensions
+COPY --from=build /dist /dist
+RUN pip install --no-cache-dir /dist/*.whl mkdocstrings-python \
+    && rm -rf /dist
 
 # Set working directory and expose preview server port
 WORKDIR /docs


### PR DESCRIPTION
This PR swaps out the container base image from `scratch` to `alpine`. The main goal here is to get things playing nicely with GitLab CI. This solution also allows user to more easily extend the container image since the alpine package manager is now included.

I went down a bit of a rabbit hole trying a few different solutions, and this one definitely hits the sweet spot. We do lose the pure `FROM scratch` setup, but the neat part is that the final image is actually quite a bit smaller!

| **Metric** | **Old Image (scratch)** | **This PR (alpine)** |
| --- | --- | --- |
| **Size** | 144 MB | 122 MB |
| **Layers** | 6 | 8 |

Fixes #510


# What Else I Tried

**1. Copying just `/bin`**

I tried changing the `/bin/sh` copy command to grab the whole `/bin` directory. This got basic commands like `grep`, `mkdir`, and `touch` working, but the GitLab CI job still ended up getting stuck.

**2. Brute-forcing more folders**

I tried a `COPY` on some additional folders. This actually resulted in a working image in GitLab CI, but the overall size ballooned to 240 MB.

**3. Busybox static binaries**

I explored using statically linked binaries from busybox, similar to what I mentioned in issue #510:

```Dockerfile
FROM busybox:1.37.0 AS busybox
FROM scratch AS image

# Copy relevant files from build
COPY --from=busybox /bin /bin
COPY --from=build /sbin/tini /sbin/tini
...

```

This worked, and the image size was basically the same. However, mixing Alpine and Busybox felt a bit messy to maintain (even though Alpine relies heavily on Busybox under the hood anyway).

**4. Just alpine as Image**

This was definitely the smallest option. I actually managed to get the build down to **77 MB!**

https://github.com/Skaronator/zensical/commit/6b4ae6ce80c55d0c87681b3b4b72fecfdacf6097

As cool as that was, it felt pretty hacky. I had to install dependencies right in the final layer just to make sure Python kept working, so I decided against it for the sake of clean architecture.