### PR TITLE
chore: update actions to versions with Node 24 support

### DIFF
--- a/python/zensical/bootstrap/.github/workflows/docs.yml
+++ b/python/zensical/bootstrap/.github/workflows/docs.yml
@@ -15,15 +15,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/configure-pages@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: pip install zensical
       - run: zensical build --clean
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment


### PR DESCRIPTION
<!--
  Before opening a PR, please read our contributing guide:
  https://zensical.org/docs/community/contribute/pull-requests/
-->

## Summary

GitHub is deprecating Node.js 20 actions starting from June 2026. This PR updates the versions of the actions in the template `docs.yml` to newer versions with Node.js 24 support.

## Related issue

Closes https://github.com/zensical/zensical/issues/522

## Checklist

<!-- All boxes must be checked -->

Please ensure that your PR meets the following requirements:

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
