### PR TITLE
fix: out of date help message for new command (#524)

### DIFF
--- a/python/zensical/main.py
+++ b/python/zensical/main.py
@@ -137,10 +137,10 @@ def execute_serve(config_file: str | None, **kwargs: Any) -> None:
 def new_project(directory: str | None, **kwargs: Any) -> None:  # noqa: ARG001
     """Create a new template project in the current or given directory.
 
-    Raises:
-        ClickException: if the directory already contains a zensical.toml or a
-            docs directory that is not empty, as well as when the path provided
-            points to something that is not a directory.
+    The new command returns with an error if the path provided is not a
+    directory or if it already contains a zensical.toml file. If other
+    files that are part of the template exist then they will not be
+    overwritten but the new command will succeed.
     """
     working_dir = Path.cwd() if directory is None else Path(directory).resolve()
     if working_dir.is_file():


### PR DESCRIPTION
## Summary

fixes an out of date help message for the new command

## Related issue

This pull request is linked to the following issue:

https://github.com/zensical/zensical/issues/524

## Checklist

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] there is an issue for this PR
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
