### PR TITLE
fix: always rebuild pages containing snippets (#526)

### DIFF
--- a/crates/zensical/src/workflow.rs
+++ b/crates/zensical/src/workflow.rs
@@ -196,13 +196,20 @@ pub fn process_markdown(
                     url
                 };
 
-                cached(
-                    &config,
-                    id,
-                    (config.hash, data.clone(), url.clone()),
-                    |(_, data, url)| Markdown::new(id, url, data),
-                )
-                .into_report()
+                // Don't cache page if it inserts (pymdownx) snippets.
+                // This is a hack while waiting for CommonMark (AST) and components,
+                // as well as topic-based authoring functionality.
+                if data.contains("--8<--") {
+                    Markdown::new(id, url, data).into_report()
+                } else {
+                    cached(
+                        &config,
+                        id,
+                        (config.hash, data.clone(), url.clone()),
+                        |(_, data, url)| Markdown::new(id, url, data),
+                    )
+                    .into_report()
+                }
             }),
             1,
         )


### PR DESCRIPTION
## Summary

Always rebuild pages that insert (pymdownx) snippets.

## Related issue

This pull request is linked to the following issue: #526

## Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
