### PR TITLE
fix: update README.html links to index.html links when directory URLs aren't set (#531)

### DIFF
--- a/python/zensical/extensions/links.py
+++ b/python/zensical/extensions/links.py
@@ -85,12 +85,14 @@ class LinksProcessor(Treeprocessor):
             path = url.path
             if path.endswith(".md"):
                 path = path.removesuffix(".md") + ".html"
+                name = get_name(path)
                 if self.use_directory_urls:
-                    name = get_name(path)
                     if name in ("index.html", "README.html"):
-                        path = path[: -len(name)]
+                        path = path.removesuffix(name)
                     elif path.endswith(".html"):
-                        path = path[: -len(".html")] + "/"
+                        path = path.removesuffix(".html") + "/"
+                elif name == "README.html":
+                    path = path.removesuffix("README.html") + "index.html"
 
             # If the current page is not an index page, and we should render
             # directory URLs, we need to prepend a "../" to all links


### PR DESCRIPTION

<!--
  Before opening a PR, please read our contributing guide:
  https://zensical.org/docs/community/contribute/pull-requests/
-->

## Summary

README.md file are built as index.html files. Yet links pointing to README.md files weren't updated to use index.html instead of README.html when `use_directory_urls` is false.

## Related issue

This pull request is linked to the following issue: #531

## Checklist

<!-- All boxes must be checked -->

Please ensure that your PR meets the following requirements:

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
