### PR TITLE
fix: detect snippets block syntax (#526)

### DIFF
--- a/crates/zensical/src/workflow.rs
+++ b/crates/zensical/src/workflow.rs
@@ -54,7 +54,7 @@ mod cached;
 use cached::cached;
 
 static SNIPPET_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[ \t]*-+8<-+[ \t]+").expect("invariant"));
+    LazyLock::new(|| Regex::new(r"^[ \t]*-+8<-+").expect("invariant"));
 
 // ----------------------------------------------------------------------------
 // Functions


### PR DESCRIPTION
See https://github.com/zensical/zensical/issues/526#issuecomment-4255929027, thanks @kamilkrzyskow :blush: 

In theory we risk matching even more false-positives, but in practice I don't think we can find a lot of `--8<--` occurrences which are not snippets.