### PR TITLE
fix: inhibit page previews on footnote backrefs

### DIFF
--- a/python/zensical/extensions/preview.py
+++ b/python/zensical/extensions/preview.py
@@ -102,6 +102,8 @@ class PreviewProcessor(Treeprocessor):
                 # Skip footnotes
                 if "footnote-ref" in el.get("class", ""):
                     continue
+                if "footnote-backref" in el.get("class", ""):
+                    continue
 
                 # Skip headerlinks
                 if "headerlink" in el.get("class", ""):


### PR DESCRIPTION
<!--
  Before opening a PR, please read our contributing guide:
  https://zensical.org/docs/community/contribute/pull-requests/
-->

## Summary

<!-- Briefly describe what this PR does and why -->

- Stops page previews being generated on backrefs of footnotes overlaying the actual tooltip to jump back

## Related issue

<!-- Every PR from an outside contributor must be linked to an issue -->

None. It's a very simple code change, take it or leave it.

## Checklist

<!-- All boxes must be checked -->

Please ensure that your PR meets the following requirements:

- [X] I have read the [pull request guide] and confirm it meets all outlined requirements
- [ ] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [X] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [X] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
