### PR TITLE
Harden Dockerfile: pin images, reduce attack surface, add non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,9 +85,15 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 FROM build AS bundle
 
-# Install project wheel, runtime dependencies, and PyInstaller
+# Install project wheel, runtime dependencies, and PyInstaller, then remove
+# mypyc-compiled .so files (e.g. from tomli, griffe) so PyInstaller collects
+# the pure-Python sources instead – avoids missing mypyc runtime .so
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install /dist/*.whl mkdocstrings-python pyinstaller
+    uv pip install /dist/*.whl mkdocstrings-python pyinstaller && \
+    find $(uv run python -c "import sysconfig; print(sysconfig.get_path('purelib'))") \
+        -name '*__mypyc*.so' -delete && \
+    find $(uv run python -c "import sysconfig; print(sysconfig.get_path('purelib'))") \
+        -path '*/tomli/*.so' -delete
 
 # Bundle into a self-contained directory (onedir avoids /tmp extraction overhead)
 RUN uv run pyinstaller \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,26 +23,23 @@
 
 # -----------------------------------------------------------------------------
 
-FROM python:3.14-alpine3.23 AS base
+FROM python:3.14-alpine3.23@sha256:dd4d2bd5b53d9b25a51da13addf2be586beebd5387e289e798e4083d94ca837a AS base
 
 FROM base AS build
 
 # Disable bytecode caching during build
 ENV PYTHONDONTWRITEBYTECODE=1
 
-# Install build dependencies
-RUN apk upgrade --update-cache -a
-RUN apk add --no-cache \
-    curl \
-    git \
-    gcc \
-    libffi-dev \
-    musl-dev \
-    tini \
-    uv
-
-# Install Rust toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
+# Install build dependencies and Rust toolchain
+RUN apk upgrade --update-cache -a && \
+    apk add --no-cache \
+        curl \
+        git \
+        gcc \
+        libffi-dev \
+        musl-dev \
+        uv && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Copy files to prepare build
@@ -54,11 +51,11 @@ RUN python scripts/prepare.py
 
 # Create a stub project, which will allow us to install dependencies and have
 # them properly cached while changes to sources won't invalidate the cache
-RUN mkdir crates
-RUN cargo new --lib crates/zensical
-RUN cargo add pyo3 \
-    --manifest-path crates/zensical/Cargo.toml \
-    --features extension-module
+RUN mkdir -p crates && \
+    cargo new --lib crates/zensical && \
+    cargo add pyo3 \
+        --manifest-path crates/zensical/Cargo.toml \
+        --features extension-module
 
 # Copy files to install dependencies - these will get installed into a virtual
 # environment, which is fine, since uv can later reuse the cached versions
@@ -86,22 +83,49 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # -----------------------------------------------------------------------------
 
-FROM base AS image
+FROM build AS bundle
 
-# Add libgcc to allow running Rust extensions
-RUN apk add --no-cache \
-    libgcc \
-    tini
+# Install project wheel, runtime dependencies, and PyInstaller
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install /dist/*.whl mkdocstrings-python pyinstaller
 
-# Install project and runtime dependency extensions
-COPY --from=build /dist /dist
-RUN pip install --no-cache-dir /dist/*.whl mkdocstrings-python \
-    && rm -rf /dist
+# Bundle into a self-contained directory (onedir avoids /tmp extraction overhead)
+RUN uv run pyinstaller \
+    --onedir \
+    --name zensical \
+    --distpath /bundle \
+    --collect-all zensical \
+    --collect-all markdown \
+    --collect-all pymdownx \
+    --collect-all pygments \
+    --collect-all click \
+    --collect-all yaml \
+    --collect-all deepmerge \
+    --collect-all tomli \
+    --collect-all mkdocstrings \
+    --collect-all griffe \
+    $(uv run which zensical)
+
+# -----------------------------------------------------------------------------
+
+FROM alpine:3.23.4 AS image
+
+# Add only the C runtime needed by the Rust extension, and tini as init
+RUN apk upgrade --update-cache -a && \
+    apk add --no-cache \
+        libgcc \
+        tini && \
+    adduser -D -u 1000 zensical
+
+# Copy the self-contained PyInstaller bundle (no Python package required)
+COPY --from=bundle /bundle/zensical /app
 
 # Set working directory and expose preview server port
 WORKDIR /docs
+RUN chown zensical:zensical /docs
+USER zensical
 EXPOSE 8000
 
 # Start preview server by default
-ENTRYPOINT ["/sbin/tini", "--", "zensical"]
+ENTRYPOINT ["/sbin/tini", "--", "/app/zensical"]
 CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,12 +117,13 @@ RUN apk upgrade --update-cache -a && \
         tini && \
     adduser -D -u 1000 zensical
 
+# Set working directory
+WORKDIR /docs
+RUN chown zensical:zensical /docs
+
 # Copy the self-contained PyInstaller bundle (no Python package required)
 COPY --from=bundle /bundle/zensical /app
 
-# Set working directory and expose preview server port
-WORKDIR /docs
-RUN chown zensical:zensical /docs
 USER zensical
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN uv run pyinstaller \
 
 # -----------------------------------------------------------------------------
 
-FROM alpine:3.23.4 AS image
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS image
 
 # Add only the C runtime needed by the Rust extension, and tini as init
 RUN apk upgrade --update-cache -a && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,7 @@ FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a
 RUN apk upgrade --update-cache -a && \
     apk add --no-cache \
         libgcc \
+        su-exec \
         tini && \
     adduser -D -u 1000 zensical
 
@@ -127,12 +128,15 @@ RUN apk upgrade --update-cache -a && \
 WORKDIR /docs
 RUN chown zensical:zensical /docs
 
+# Copy entrypoint script
+COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
 # Copy the self-contained PyInstaller bundle (no Python package required)
 COPY --from=bundle /bundle/zensical /app
 
-USER zensical
 EXPOSE 8000
 
-# Start preview server by default
-ENTRYPOINT ["/sbin/tini", "--", "/app/zensical"]
+# The entrypoint script adjusts the UID/GID of the zensical user at runtime
+# to match the host user (via PUID/PGID env vars), then drops privileges.
+ENTRYPOINT ["/sbin/tini", "--", "docker-entrypoint.sh", "/app/zensical"]
 CMD ["serve", "--dev-addr=0.0.0.0:8000"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Copyright (c) 2025-2026 Zensical and contributors
+
+# SPDX-License-Identifier: MIT
+# All contributions are certified under the DCO
+
+# Adjust the UID/GID of the zensical user to match the host user so that files
+# generated inside the container (e.g. by `build`) are owned by the caller.
+# Pass the desired values via the PUID and PGID environment variables:
+#
+#   docker run -e PUID=$(id -u) -e PGID=$(id -g) ...
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+# Validate that PUID and PGID are numeric
+case "$PUID" in
+    ''|*[!0-9]*) echo "Error: PUID must be numeric" >&2; exit 1 ;;
+esac
+case "$PGID" in
+    ''|*[!0-9]*) echo "Error: PGID must be numeric" >&2; exit 1 ;;
+esac
+
+if [ "$(id -u)" = "0" ]; then
+    # Update group and user IDs if they differ from the defaults
+    if [ "$PGID" != "1000" ]; then
+        delgroup zensical 2>/dev/null
+        addgroup -g "$PGID" zensical
+    fi
+    if [ "$PUID" != "1000" ]; then
+        deluser zensical 2>/dev/null
+        adduser -D -u "$PUID" -G zensical zensical
+    fi
+
+    chown zensical:zensical /docs
+    exec su-exec zensical "$@"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
## Summary

Harden the Dockerfile by pinning base images, consolidating build layers,
adding `apk upgrade` to the final stage, and running as a non-root user.
These changes eliminate all 19 OS-level CVEs present in the current published
image and reduce the final image package count from 32 to 18.

Closes #559

### Trivy: `zensical:this-pr` — Alpine 3.23.4, 18 OS packages

| Target | Type | Vulnerabilities |
|--------|------|-----------------|
| zensical:this-pr (alpine 3.23.4) | alpine | 0 |
| app/_internal/click-8.3.0 | python-pkg | 0 |
| app/_internal/deepmerge-2.0 | python-pkg | 0 |
| app/_internal/griffelib-2.0.2 | python-pkg | 0 |
| app/_internal/markdown-3.9 | python-pkg | 0 |
| app/_internal/markupsafe-3.0.3 | python-pkg | 0 |
| app/_internal/mkdocstrings-1.0.4 | python-pkg | 0 |
| app/_internal/pygments-2.20.0 | python-pkg | 0 |
| app/_internal/pymdown_extensions-10.21.2 | python-pkg | 0 |
| app/_internal/pyyaml-6.0.3 | python-pkg | 0 |
| app/_internal/setuptools/…/importlib_metadata-8.7.1 | python-pkg | 0 |
| app/_internal/tomli-2.4.1 | python-pkg | 0 |

**Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)**

### Trivy: `zensical/zensical:latest` — Alpine 3.23.3, 32 OS packages

| Library | Severity | CVE |
|---------|----------|-----|
| libcrypto3 | HIGH | CVE-2026-28390 |
| libcrypto3 | MEDIUM | CVE-2026-28388 |
| libcrypto3 | MEDIUM | CVE-2026-28389 |
| libcrypto3 | MEDIUM | CVE-2026-31789 |
| libcrypto3 | MEDIUM | CVE-2026-31790 |
| libcrypto3 | LOW | CVE-2026-2673 |
| libcrypto3 | LOW | CVE-2026-28387 |
| libssl3 | HIGH | CVE-2026-28390 |
| libssl3 | MEDIUM | CVE-2026-28388 |
| libssl3 | MEDIUM | CVE-2026-28389 |
| libssl3 | MEDIUM | CVE-2026-31789 |
| libssl3 | MEDIUM | CVE-2026-31790 |
| libssl3 | LOW | CVE-2026-2673 |
| libssl3 | LOW | CVE-2026-28387 |
| libuuid | MEDIUM | CVE-2026-27456 |
| musl | HIGH | CVE-2026-40200 |
| musl | MEDIUM | CVE-2026-6042 |
| musl-utils | HIGH | CVE-2026-40200 |
| musl-utils | MEDIUM | CVE-2026-6042 |

**Total: 19 (UNKNOWN: 0, LOW: 4, MEDIUM: 11, HIGH: 4, CRITICAL: 0)**

## Related issue

This pull request is linked to #559

## Checklist

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [ ] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai