### PR TITLE
chore: release v0.0.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -1377,7 +1377,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-watch"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
 zensical-serve = { version = "0.0.2", path = "crates/zensical-serve" }
-zensical-watch = { version = "0.0.4", path = "crates/zensical-watch" }
+zensical-watch = { version = "0.0.5", path = "crates/zensical-watch" }
 
 ahash = "0.8"
 base64 = "0.22"

--- a/crates/zensical-watch/Cargo.toml
+++ b/crates/zensical-watch/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-watch"
-version = "0.0.4"
+version = "0.0.5"
 description = "Resilient file watcher"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.33"
+version = "0.0.34"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version ships support for usage of TOML v1.1.0 in `zensical.toml`, which allows new lines in inline tables. Thus, configuration files can now be made more readable, especially when they contain long lists of items. For example:

__Prior to this version__

``` toml
palette = [
  { scheme = "default", toggle = { icon = "lucide/sun", name = "Switch to dark mode" } },
  { scheme = "slate", toggle = { icon = "lucide/moon", name = "Switch to light mode" } },
]
```

__With this version__

``` toml
palette = [
  {
    scheme = "default",
    toggle = {
      icon = "lucide/sun",
      name = "Switch to dark mode"
    }
  },
  {
    scheme = "slate",
    toggle = {
      icon = "lucide/moon",
      name = "Switch to light mode"
    }
  },
]
```

Additionally, Markdown pages with snippets are now rebuilt when snippets are updated, and an issue with breadcrumbs was fixed when the top-level `index.md` was not at the root of `nav` defined explicitly.