### PR TITLE
chore: remove license from wheel root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ description = "A modern static site generator built by the creators of Material 
 authors = [
     { name = "Zensical", email = "contributors@zensical.org" }
 ]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE.md"]
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
@@ -82,5 +83,4 @@ manifest-path = "crates/zensical/Cargo.toml"
 include = [
   "python/zensical/bootstrap/**/*",
   "python/zensical/templates/**/*",
-  "LICENSE.md",
 ]


### PR DESCRIPTION
Quick PR to remove the LICENSE.md file from the wheel root (it would be unpacked at the root of a venv's site-packages). Far from critical, just cleaning up. Also updated `license` to the new format.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files.