### PR TITLE
fix: support uv's symlink mode (#557)

### DIFF
--- a/crates/zensical/src/watcher.rs
+++ b/crates/zensical/src/watcher.rs
@@ -114,9 +114,22 @@ impl Watcher {
             let config = config.clone();
             move |res| {
                 // For now, we just swallow the event, as the file agent should
-                // to take care of it, and skip anything other than files
+                // Skip anything other than files and symbolic links.
+                // Link events allow assets provided via editable installs
+                // (e.g. symlinked theme directories) to enter the build.
                 if let Ok(event) = res {
-                    if event.kind() != Kind::File {
+                    if !matches!(event.kind(), Kind::File | Kind::Link) {
+                        return Ok(());
+                    }
+
+                    // Ignore symbolic links that don't resolve to files.
+                    // Directory links are expanded by the watcher backend,
+                    // but forwarding the link itself would later be treated as
+                    // a file in the workflow and can fail with IsADirectory.
+                    if event.kind() == Kind::Link
+                        && !fs::metadata(event.path().as_path())
+                            .is_ok_and(|meta| meta.is_file())
+                    {
                         return Ok(());
                     }
 


### PR DESCRIPTION
## Summary

Support uv's symlink mode when installing Zensical. In symlink mode, uv recreates the package layout (folders), and create symlinks pointing to its cache for every file. The change in this PR makes it so that Zensical doesn't skip those files wen copying (theme) assets.

## Related issue

This pull request is linked to the following issue: #557

## Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
