### PR TITLE
chore: release v0.0.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.34"
+version = "0.0.35"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds native support for [GLightbox], a JavaScript lightbox library to add zoom and gallery features to images. Images can be automatically annotated with the new `glightbox` Markdown extension. Add the following to `zensical.toml`:

``` toml
[project.markdown_extensions.zensical.extensions.glightbox]
```

> [!NOTE]
>
> In order to integrate with configuration in `mkdocs.yml`, where [GLightbox] is implemented as a plugin, a compatibility shim is included, so no re-configuration is necessary if you're already using the plugin. Note that our extension is more efficient and faster than the plugin, as it does not re-parse the entire HTML of each page, but instead uses Python Markdown's native extension API.

### HTML in the table of contents

Additionally, __section titles in the table of contents will now render with HTML markup__, so you can use emojis and other inline features in section titles and have them render correctly in the table of contents. In Material for MkDocs, this functionality was implemented with the `typeset` plugin. Zensical now supports this natively.

### Relative links in raw HTML

Relative links in raw HTML are now correctly resolved. Initially, we carried over the link processing and resolution logic from MkDocs, which does not support relative links in raw HTML to this day. We implemented a Python Markdown postprocessor, to ensure that relative links in raw HTML are handled as well.

[GLightbox]: https://biati-digital.github.io/glightbox/
