### PR TITLE
chore: add spacing in markdown example

### DIFF
--- a/python/zensical/bootstrap/docs/markdown.md
+++ b/python/zensical/bootstrap/docs/markdown.md
@@ -5,6 +5,7 @@ icon: simple/markdown
 # Markdown in 5min
 
 ## Headers
+
 ```
 # H1 Header
 ## H2 Header
@@ -15,6 +16,7 @@ icon: simple/markdown
 ```
 
 ## Text formatting
+
 ```
 **bold text**
 *italic text*
@@ -24,6 +26,7 @@ icon: simple/markdown
 ```
 
 ## Links and images
+
 ```
 [Link text](https://example.com)
 [Link with title](https://example.com "Hover title")
@@ -32,19 +35,23 @@ icon: simple/markdown
 ```
 
 ## Lists
+
 ```
 Unordered:
+
 - Item 1
 - Item 2
   - Nested item
 
 Ordered:
+
 1. First item
 2. Second item
 3. Third item
 ```
 
 ## Blockquotes
+
 ```
 > This is a blockquote
 > Multiple lines
@@ -52,6 +59,7 @@ Ordered:
 ```
 
 ## Code blocks
+
 ````
 ```javascript
 function hello() {
@@ -61,6 +69,7 @@ function hello() {
 ````
 
 ## Tables
+
 ```
 | Header 1 | Header 2 | Header 3 |
 |----------|----------|----------|
@@ -69,6 +78,7 @@ function hello() {
 ```
 
 ## Horizontal rule
+
 ```
 ---
 or
@@ -78,6 +88,7 @@ ___
 ```
 
 ## Task lists
+
 ```
 - [x] Completed task
 - [ ] Incomplete task
@@ -85,11 +96,13 @@ ___
 ```
 
 ## Escaping characters
+
 ```
 Use backslash to escape: \* \_ \# \`
 ```
 
 ## Line breaks
+
 ```
 End a line with two spaces  
 to create a line break.


### PR DESCRIPTION
This also makes the markup for lists compliant with Python-Markdown (required blank line before).

---

Someone mentioned it on Discord. Even though this won't be required by CommonMark, I think it's rather good practice to add a blank line after a title and before a list. I think that's what Markdown formatters do anyway, too. Plus if someone re-configures Markdown extensions (disabling most of them in the process), this page will still show examples that work, maybe improving the learning process for new Markdown users (both when reading the source and rendered page).