### PR TITLE
chore: release v0.0.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.36"
+version = "0.0.37"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.36"
+version = "0.0.37"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds support for installable themes. You can now bundle your theme overrides and package them into a custom theme which can be installed via `pip`.

As of now, we closely mirror the process used by MkDocs, where themes just need to register themselves in the `mkdocs.themes` entrypoint, to allow users that already have derivations of Material for MkDocs to run them on Zensical. In the coming months, with the advent of the [component system], we'll make this process much more flexible and foster reuse at the component level. For now, this is a first step to allow sharing of theme overrides and default configurations inside organizations with dozens or even thousands of projects.

> [!TIP]
>
> If your organization has been a happy user of Material for MkDocs and is considering switching to Zensical, please support our work through [Zensical Spark]. Your financial contribution helps us achieve full compatibility with MkDocs much faster, gives you access to hands-on support by the core team, and allows you to shape Zensical together with us.

[component system]: https://zensical.org/about/roadmap/#component-system
[Zensical Spark]: https://zensical.org/spark/
