### PR TITLE
refactor: use our markdown subclasses

### DIFF
--- a/crates/zensical/src/structure/markdown.rs
+++ b/crates/zensical/src/structure/markdown.rs
@@ -81,7 +81,7 @@ impl Markdown {
         let id = id.clone();
         let guard = RENDER_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
         let res = Python::attach(|py| {
-            let module = py.import("zensical.markdown")?;
+            let module = py.import("zensical.markdown.render")?;
             module
                 .call_method1("render", (content, id.location(), url))?
                 .extract::<Markdown>()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ dev = [
     "maturin>=1.10.2",
     "ruff>=0.12.8",
     "ty>=0.0.32",
-    "types-markdown>=3.10.0",
     "types-pyyaml>=6.0.12",
 ]
 

--- a/python/zensical/extensions/emoji.py
+++ b/python/zensical/extensions/emoji.py
@@ -32,14 +32,14 @@ from xml.etree.ElementTree import Element
 from pymdownx import emoji, twemoji_db
 
 if TYPE_CHECKING:
-    from markdown import Markdown
+    from zensical.markdown import MarkdownExt
 
 # -----------------------------------------------------------------------------
 # Functions
 # -----------------------------------------------------------------------------
 
 
-def twemoji(options: dict, md: Markdown) -> dict:  # noqa: ARG001
+def twemoji(options: dict, md: MarkdownExt) -> dict:  # noqa: ARG001
     """Create twemoji index."""
     paths = options.get("custom_icons", [])[:]
     return _load_twemoji_index(tuple(paths))
@@ -54,7 +54,7 @@ def to_svg(
     title: str,
     category: str,
     options: dict,
-    md: Markdown,
+    md: MarkdownExt,
 ) -> Element[str]:
     """Load icon."""
     if not uc:

--- a/python/zensical/extensions/emoji.py
+++ b/python/zensical/extensions/emoji.py
@@ -32,7 +32,7 @@ from xml.etree.ElementTree import Element
 from pymdownx import emoji, twemoji_db
 
 if TYPE_CHECKING:
-    from zensical.markdown import MarkdownExt
+    from zensical.markdown.extensions import MarkdownExt
 
 # -----------------------------------------------------------------------------
 # Functions

--- a/python/zensical/extensions/glightbox.py
+++ b/python/zensical/extensions/glightbox.py
@@ -27,11 +27,11 @@ import re
 from typing import TYPE_CHECKING, Any, cast
 from xml.etree.ElementTree import Element, ParseError, fromstring, tostring
 
-from zensical.markdown import ExtensionExt, MarkdownExt
+from zensical.markdown.extensions import ExtensionExt, MarkdownExt
 from zensical.markdown.processors import PostprocessorExt, TreeprocessorExt
 
 if TYPE_CHECKING:
-    from zensical.markdown import MarkdownExt
+    from zensical.markdown.extensions import MarkdownExt
 
 # -----------------------------------------------------------------------------
 # Constants

--- a/python/zensical/extensions/glightbox.py
+++ b/python/zensical/extensions/glightbox.py
@@ -27,12 +27,11 @@ import re
 from typing import TYPE_CHECKING, Any, cast
 from xml.etree.ElementTree import Element, ParseError, fromstring, tostring
 
-from markdown.extensions import Extension
-from markdown.postprocessors import Postprocessor
-from markdown.treeprocessors import Treeprocessor
+from zensical.markdown import ExtensionExt, MarkdownExt
+from zensical.markdown.processors import PostprocessorExt, TreeprocessorExt
 
 if TYPE_CHECKING:
-    from markdown import Markdown
+    from zensical.markdown import MarkdownExt
 
 # -----------------------------------------------------------------------------
 # Constants
@@ -46,14 +45,14 @@ _RE = re.compile(r"<img\s[^>]*?>", re.IGNORECASE)
 # -----------------------------------------------------------------------------
 
 
-class GlightboxTreeprocessor(Treeprocessor):
+class GlightboxTreeprocessor(TreeprocessorExt):
     """Wraps image elements in anchor tags to integrate with GLightbox."""
 
     SKIP_CLASSES: frozenset[str] = frozenset(
         {"emojione", "twemoji", "gemoji", "off-glb"}
     )
 
-    def __init__(self, md: Markdown, config: dict[str, object]):
+    def __init__(self, md: MarkdownExt, config: dict[str, object]):
         super().__init__(md)
         self.config = config
 
@@ -174,7 +173,7 @@ class GlightboxTreeprocessor(Treeprocessor):
         )
 
 
-class GlightboxPostprocessor(Postprocessor):
+class GlightboxPostprocessor(PostprocessorExt):
     """Wraps stashed images in anchors, delegating to the treeprocessor.
 
     This postprocessor uses a regular expression to find image tags in stashed
@@ -183,7 +182,7 @@ class GlightboxPostprocessor(Postprocessor):
     parse and modify the HTML with an actual parser.
     """
 
-    def __init__(self, md: Markdown, config: dict[str, object]):
+    def __init__(self, md: MarkdownExt, config: dict[str, object]):
         super().__init__(md)
         self._processor = GlightboxTreeprocessor(md, config)
         self._processed: set[int] = set()
@@ -197,7 +196,7 @@ class GlightboxPostprocessor(Postprocessor):
         """Wrap images in stashed HTML blocks."""
         for i, raw in enumerate(self.md.htmlStash.rawHtmlBlocks):
             if i not in self._processed:
-                self.md.htmlStash.rawHtmlBlocks[i] = _RE.sub(
+                self.md.htmlStash.rawHtmlBlocks[i] = _RE.sub(  # ty:ignore[no-matching-overload]
                     self._maybe_process, raw
                 )
                 self._processed.add(i)
@@ -228,7 +227,7 @@ class GlightboxPostprocessor(Postprocessor):
 # -----------------------------------------------------------------------------
 
 
-class GlightboxExtension(Extension):
+class GlightboxExtension(ExtensionExt):
     """Markdown extension that wraps images in GLightbox anchor tags.
 
     This extension provides both a treeprocessor to wrap images in the normal
@@ -265,7 +264,7 @@ class GlightboxExtension(Extension):
         }
         super().__init__(**kwargs)
 
-    def extendMarkdown(self, md: Markdown) -> None:  # noqa: N802
+    def extendMarkdown(self, md: MarkdownExt) -> None:  # noqa: N802
         """Register Markdown extension."""
         md.registerExtension(self)
 

--- a/python/zensical/extensions/links.py
+++ b/python/zensical/extensions/links.py
@@ -30,13 +30,13 @@ from urllib.parse import urlparse
 
 from markdown.util import AMP_SUBSTITUTE
 
-from zensical.markdown import ExtensionExt
+from zensical.markdown.extensions import ExtensionExt
 from zensical.markdown.processors import PostprocessorExt, TreeprocessorExt
 
 if TYPE_CHECKING:
     from xml.etree.ElementTree import Element
 
-    from zensical.markdown import MarkdownExt
+    from zensical.markdown.extensions import MarkdownExt
 
 # -----------------------------------------------------------------------------
 # Constants

--- a/python/zensical/extensions/links.py
+++ b/python/zensical/extensions/links.py
@@ -28,15 +28,15 @@ from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-from markdown.extensions import Extension
-from markdown.postprocessors import Postprocessor
-from markdown.treeprocessors import Treeprocessor
 from markdown.util import AMP_SUBSTITUTE
+
+from zensical.markdown import ExtensionExt
+from zensical.markdown.processors import PostprocessorExt, TreeprocessorExt
 
 if TYPE_CHECKING:
     from xml.etree.ElementTree import Element
 
-    from markdown import Markdown
+    from zensical.markdown import MarkdownExt
 
 # -----------------------------------------------------------------------------
 # Constants
@@ -53,10 +53,10 @@ _RE = re.compile(
 # -----------------------------------------------------------------------------
 
 
-class LinksTreeprocessor(Treeprocessor):
+class LinksTreeprocessor(TreeprocessorExt):
     """Rewrites relative links."""
 
-    def __init__(self, md: Markdown, path: str, use_directory_urls: bool):
+    def __init__(self, md: MarkdownExt, path: str, use_directory_urls: bool):
         super().__init__(md)
         self.path = path
         self.use_directory_urls = use_directory_urls
@@ -77,7 +77,7 @@ class LinksTreeprocessor(Treeprocessor):
                 el.set(key, url)
 
 
-class LinksPostprocessor(Postprocessor):
+class LinksPostprocessor(PostprocessorExt):
     """Rewrites relative links in stashed raw HTML blocks.
 
     This postprocessor complements the :class:`LinksTreeprocessor` by applying
@@ -86,7 +86,7 @@ class LinksPostprocessor(Postprocessor):
     inside raw HTML are handled consistently as well.
     """
 
-    def __init__(self, md: Markdown, path: str, use_directory_urls: bool):
+    def __init__(self, md: MarkdownExt, path: str, use_directory_urls: bool):
         super().__init__(md)
         self._path = path
         self._use_directory_urls = use_directory_urls
@@ -96,7 +96,7 @@ class LinksPostprocessor(Postprocessor):
         """Rewrite `href` and `src` attributes of stashed HTML blocks."""
         for i, raw in enumerate(self.md.htmlStash.rawHtmlBlocks):
             if i not in self._processed:
-                self.md.htmlStash.rawHtmlBlocks[i] = _RE.sub(
+                self.md.htmlStash.rawHtmlBlocks[i] = _RE.sub(  # ty:ignore[no-matching-overload]
                     self._maybe_process, raw
                 )
                 self._processed.add(i)
@@ -123,7 +123,7 @@ class LinksPostprocessor(Postprocessor):
 # -----------------------------------------------------------------------------
 
 
-class LinksExtension(Extension):
+class LinksExtension(ExtensionExt):
     """Markdown extension to rewrite relative links to other files.
 
     Registers both a treeprocessor for links in the normal Markdown flow and
@@ -137,7 +137,7 @@ class LinksExtension(Extension):
         self.path = path
         self.use_directory_urls = use_directory_urls
 
-    def extendMarkdown(self, md: Markdown) -> None:  # noqa: N802
+    def extendMarkdown(self, md: MarkdownExt) -> None:  # noqa: N802
         """Register Markdown extension."""
         md.registerExtension(self)
 

--- a/python/zensical/extensions/preview.py
+++ b/python/zensical/extensions/preview.py
@@ -29,7 +29,7 @@ from urllib.parse import urlparse
 
 from zensical.extensions.links import LinksTreeprocessor
 from zensical.extensions.utilities.filter import Filter
-from zensical.markdown import ExtensionExt, MarkdownExt
+from zensical.markdown.extensions import ExtensionExt, MarkdownExt
 from zensical.markdown.processors import TreeprocessorExt
 
 if TYPE_CHECKING:

--- a/python/zensical/extensions/preview.py
+++ b/python/zensical/extensions/preview.py
@@ -27,11 +27,10 @@ import posixpath
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-from markdown import Extension, Markdown
-from markdown.treeprocessors import Treeprocessor
-
 from zensical.extensions.links import LinksTreeprocessor
 from zensical.extensions.utilities.filter import Filter
+from zensical.markdown import ExtensionExt, MarkdownExt
+from zensical.markdown.processors import TreeprocessorExt
 
 if TYPE_CHECKING:
     from xml.etree.ElementTree import Element
@@ -41,14 +40,14 @@ if TYPE_CHECKING:
 # -----------------------------------------------------------------------------
 
 
-class PreviewProcessor(Treeprocessor):
+class PreviewProcessor(TreeprocessorExt):
     """A Markdown treeprocessor to enable instant previews on links.
 
     Note that this treeprocessor is dependent on the `links` treeprocessor
     registered programmatically before rendering a page.
     """
 
-    def __init__(self, md: Markdown, config: dict):
+    def __init__(self, md: MarkdownExt, config: dict):
         """Initialize the treeprocessor."""
         super().__init__(md)
         self.config = config
@@ -126,7 +125,7 @@ class PreviewProcessor(Treeprocessor):
 # -----------------------------------------------------------------------------
 
 
-class PreviewExtension(Extension):
+class PreviewExtension(ExtensionExt):
     """Markdown extension to enable instant previews on links.
 
     This extensions allows to automatically add the `data-preview` attribute to
@@ -144,7 +143,7 @@ class PreviewExtension(Extension):
         }
         super().__init__(*args, **kwargs)
 
-    def extendMarkdown(self, md: Markdown) -> None:  # noqa: N802
+    def extendMarkdown(self, md: MarkdownExt) -> None:  # noqa: N802
         """Register Markdown extension."""
         md.registerExtension(self)
 

--- a/python/zensical/extensions/search.py
+++ b/python/zensical/extensions/search.py
@@ -25,18 +25,18 @@ from html import escape
 from html.parser import HTMLParser
 from typing import Any
 
-from markdown import Extension, Markdown
-from markdown.postprocessors import Postprocessor
+from zensical.markdown import ExtensionExt, MarkdownExt
+from zensical.markdown.processors import PostprocessorExt
 
 # -----------------------------------------------------------------------------
 # Classes
 # -----------------------------------------------------------------------------
 
 
-class SearchProcessor(Postprocessor):
+class SearchProcessor(PostprocessorExt):
     """Post processor to extract searchable content from the rendered HTML."""
 
-    def __init__(self, md: Markdown) -> None:
+    def __init__(self, md: MarkdownExt) -> None:
         super().__init__(md)
         self.data: list[dict[str, Any]] = []
 
@@ -71,14 +71,14 @@ class SearchProcessor(Postprocessor):
         return text
 
 
-class SearchExtension(Extension):
+class SearchExtension(ExtensionExt):
     """Markdown extension for search indexing."""
 
     def __init__(self, **kwargs: Any) -> None:
         self.config = {"keep": [set(), "Set of HTML tags to keep in output"]}
         super().__init__(**kwargs)
 
-    def extendMarkdown(self, md: Markdown) -> None:  # noqa: N802
+    def extendMarkdown(self, md: MarkdownExt) -> None:  # noqa: N802
         """Register the PostProcessor with Markdown."""
         processor = SearchProcessor(md)
         md.postprocessors.register(processor, "search", 0)

--- a/python/zensical/extensions/search.py
+++ b/python/zensical/extensions/search.py
@@ -25,7 +25,7 @@ from html import escape
 from html.parser import HTMLParser
 from typing import Any
 
-from zensical.markdown import ExtensionExt, MarkdownExt
+from zensical.markdown.extensions import ExtensionExt, MarkdownExt
 from zensical.markdown.processors import PostprocessorExt
 
 # -----------------------------------------------------------------------------

--- a/python/zensical/markdown/__init__.py
+++ b/python/zensical/markdown/__init__.py
@@ -28,7 +28,7 @@ from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 import yaml
-from markdown import Markdown
+from markdown import Extension, Markdown
 from yaml import SafeLoader
 
 from zensical.compat.autorefs import set_autorefs_page
@@ -66,6 +66,18 @@ class MarkdownExt(Markdown):
     supported by the original Markdown `Markdown` class. It allows to implement
     several features that previously required MkDocs plugins more efficiently.
     """
+
+
+class ExtensionExt(Extension):
+    """Subclass of `Extension`.
+
+    We need to subclass the `Extension` to allow access to our modified
+    `MarkdownExt` instance, which includes the page and configuration.
+    """
+
+    def extendMarkdown(self, md: MarkdownExt) -> None:  # noqa: N802  # ty:ignore[invalid-method-override]
+        """Register Markdown extension."""
+        super().extendMarkdown(md)
 
 
 # ----------------------------------------------------------------------------
@@ -121,7 +133,7 @@ def render(content: str, path: str, url: str) -> dict:
     meta = {k: _sanitize(v) for k, v in meta.items()}
 
     # Obtain search index data, unless page is excluded
-    search_processor: SearchProcessor = md.postprocessors["search"]
+    search_processor: SearchProcessor = md.postprocessors["search"]  # ty:ignore[invalid-assignment]
     if meta.get("search", {}).get("exclude", False):
         search_processor.data = []
 

--- a/python/zensical/markdown/extensions.py
+++ b/python/zensical/markdown/extensions.py
@@ -20,3 +20,34 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
+
+from __future__ import annotations
+
+from markdown import Extension, Markdown
+
+# ----------------------------------------------------------------------------
+# Classes
+# ----------------------------------------------------------------------------
+
+
+class MarkdownExt(Markdown):
+    """Subclass of `Markdown`.
+
+    We need to subclass the `Markdown` class to provide additional data to the
+    processors, such as page information and configuration, someting that isn't
+    supported by the original Markdown `Markdown` class. It allows to implement
+    several features that previously required MkDocs plugins more efficiently.
+    """
+
+
+class ExtensionExt(Extension):
+    """Subclass of `Extension`.
+
+    We need to subclass the `Extension` to allow access to our modified
+    `MarkdownExt` instance, which includes the page and configuration.
+    """
+
+    def extendMarkdown(self, md: MarkdownExt) -> None:  # noqa: N802  # ty:ignore[invalid-method-override]
+        """Register Markdown extension."""
+        super().extendMarkdown(md)
+

--- a/python/zensical/markdown/processors.py
+++ b/python/zensical/markdown/processors.py
@@ -30,7 +30,7 @@ from markdown.preprocessors import Preprocessor
 from markdown.treeprocessors import Treeprocessor
 
 if TYPE_CHECKING:
-    from zensical.markdown import MarkdownExt
+    from zensical.markdown.extensions import MarkdownExt
 
 # -----------------------------------------------------------------------------
 # Classes

--- a/python/zensical/markdown/render.py
+++ b/python/zensical/markdown/render.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2025-2026 Zensical and contributors
+
+# SPDX-License-Identifier: MIT
+# All contributions are certified under the DCO
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from __future__ import annotations
+
+import re
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from yaml import SafeLoader
+
+from zensical.compat.autorefs import set_autorefs_page
+from zensical.config import get_config
+from zensical.extensions.links import LinksExtension
+from zensical.extensions.search import SearchExtension
+from zensical.markdown.extensions import MarkdownExt
+
+if TYPE_CHECKING:
+    from zensical.extensions.search import SearchProcessor
+
+# ----------------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------------
+
+
+FRONT_MATTER_RE = re.compile(
+    r"^-{3}[ \r\t]*?\n(.*?\r?\n)(?:\.{3}|-{3})[ \r\t]*\n",
+    re.UNICODE | re.DOTALL,
+)
+"""
+Regex pattern to extract front matter.
+"""
+
+
+# ----------------------------------------------------------------------------
+# Functions
+# ----------------------------------------------------------------------------
+
+
+def render(content: str, path: str, url: str) -> dict:
+    """Render Markdown and return HTML.
+
+    This function returns rendered HTML as well as the table of contents and
+    metadata. Now, this is the part where Zensical needs to call into Python,
+    in order to support the specific syntax of Python Markdown. We're working
+    on moving the entire rendering chain to Rust.
+    """
+    config = get_config()
+
+    set_autorefs_page(url, path)
+
+    # Initialize Markdown parser
+    md = MarkdownExt(
+        extensions=config["markdown_extensions"],
+        extension_configs=config["mdx_configs"],
+    )
+
+    # Register links extension, which is equivalent to MkDocs' path resolution
+    # Markdown extension. This is a bandaid, until we move this to Rust
+    links = LinksExtension(
+        use_directory_urls=config["use_directory_urls"], path=path
+    )
+    links.extendMarkdown(md)
+
+    # Register search extension, which extracts text for search indexing
+    search_extension = SearchExtension()
+    search_extension.extendMarkdown(md)
+
+    # First, extract metadata - the Python Markdown parser brings a metadata
+    # extension, but the implementation is broken, as it does not support full
+    # YAML syntax, e.g. lists. Thus, we just parse the metadata with YAML.
+    meta: dict = {}
+    if match := FRONT_MATTER_RE.match(content):
+        try:
+            meta = yaml.load(match.group(1), SafeLoader)
+            if isinstance(meta, dict):
+                content = content[match.end() :].lstrip("\n")
+            else:
+                meta = {}
+        except Exception:  # noqa: BLE001
+            pass
+
+    # Convert Markdown and sanitize metadata before sending back to Rust
+    content = md.convert(content)
+    meta = {k: _sanitize(v) for k, v in meta.items()}
+
+    # Obtain search index data, unless page is excluded
+    search_processor: SearchProcessor = md.postprocessors["search"]  # ty:ignore[invalid-assignment]
+    if meta.get("search", {}).get("exclude", False):
+        search_processor.data = []
+
+    # Return Markdown with metadata
+    return {
+        "meta": meta,
+        "title": "",
+        "content": content,
+        "search": search_processor.data,
+        "toc": [_convert_toc(item) for item in getattr(md, "toc_tokens", [])],
+    }
+
+
+def _sanitize(value: Any) -> Any:
+    # We currently don't have a null value for metadata in the Rust runtime
+    if value is None:
+        return ""
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _sanitize(x) for k, x in value.items()}
+    if isinstance(value, list):
+        return [_sanitize(x) for x in value]
+    return value
+
+
+def _convert_toc(item: Any) -> dict:
+    """Convert a table of contents item to navigation item format."""
+    toc_item = {
+        "title": item["data-toc-label"] or item["name"],
+        "content": item["data-toc-label"] or _remove_links(item["html"]),
+        "id": item["id"],
+        "url": f"#{item['id']}",
+        "children": [],
+        "level": item["level"],
+    }
+
+    # Recursively convert items
+    for child in item["children"]:
+        toc_item["children"].append(_convert_toc(child))
+
+    # Return table of contents item
+    return toc_item
+
+
+def _remove_links(html: str) -> str:
+    """Remove links from HTML string."""
+    html = re.sub(r"id=\"?[^\">]+\"?", "", html)
+    return re.sub(r"<a\s+[^>]+>(.*?)</a>", r"\1", html, flags=re.DOTALL)

--- a/uv.lock
+++ b/uv.lock
@@ -255,15 +255,6 @@ wheels = [
 ]
 
 [[package]]
-name = "types-markdown"
-version = "3.10.2.20260408"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/0e/a690840934c459aa50e0470e7550d7f151632eafa4a8e3c21d18009ad15c/types_markdown-3.10.2.20260408.tar.gz", hash = "sha256:d5cba15ed65a1420e80e31c17e3d4a2ad7208a3f3a4da97fd2c5f093caf523cd", size = 19784, upload-time = "2026-04-08T04:33:07.644Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/7e/265a8df257c8dced6ea89295f793a19f0a49ccbfeae1ed562368b2caf7a3/types_markdown-3.10.2.20260408-py3-none-any.whl", hash = "sha256:b0bbe8b7a8174db732067b86e391262898f5f536589ea81efec6d35ceb829331", size = 25857, upload-time = "2026-04-08T04:33:06.769Z" },
-]
-
-[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20260408"
 source = { registry = "https://pypi.org/simple" }
@@ -290,7 +281,6 @@ dev = [
     { name = "maturin" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "types-markdown" },
     { name = "types-pyyaml" },
 ]
 
@@ -310,6 +300,5 @@ dev = [
     { name = "maturin", specifier = ">=1.10.2" },
     { name = "ruff", specifier = ">=0.12.8" },
     { name = "ty", specifier = ">=0.0.32" },
-    { name = "types-markdown", specifier = ">=3.10.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12" },
 ]


### PR DESCRIPTION
Use our Markdown subclasses (Markdown, extension, processors) everywhere:

- switch all pre/post/tree processors to use our subclassed versions
- create new `ExtensionExt` class to override the `extendMarkdown` method to accept `MarkdownExt`
- switch all extensions to use our subclassed version
- update type annotation in a few other places (functions)
- move MarkdownExt and ExtensionExt into extensions submodule (to resolve circular imports)
- move render function into render submodule (to resolve circular imports)

A few other typing-related changes:

- remove types-markdown from dev dependency-group (to make ty more cooperative on typing `self.md` as `MarkdownExt`)
- update lock file
- add py.typed file to package, marking it as typed (for type-checkers)