### PR TITLE
chore: release v0.0.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.39"
+version = "0.0.40"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-serve"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "base64",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-zensical-serve = { version = "0.0.2", path = "crates/zensical-serve" }
+zensical-serve = { version = "0.0.3", path = "crates/zensical-serve" }
 zensical-watch = { version = "0.0.5", path = "crates/zensical-watch" }
 
 ahash = "0.8"

--- a/crates/zensical-serve/Cargo.toml
+++ b/crates/zensical-serve/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-serve"
-version = "0.0.2"
+version = "0.0.3"
 description = "HTTP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.39"
+version = "0.0.40"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds support for [macros], covering the functionality of the `mkdocs-macros-plugin`. Macros allow you to define custom variables and functions that can be used in your Markdown files, making it easier to manage and reuse content across your documentation.

We've implemented macros support as a Python Markdown extension, since it's essentially a Markdown preprocessor that doesn't need to be aware of the rest of Zensical's rendering process, except for the current page and configuration. The benefit is that it can now also be used in Python docstrings to build API documentation with [mkdocstrings].

[macros]: https://zensical.org/docs/setup/extensions/macros/
[mkdocstrings]: https://mkdocstrings.github.io
