### PR TITLE
chore: setup reusable fixtures for extensions testing

### DIFF
--- a/python/tests/unit/extensions/conftest.py
+++ b/python/tests/unit/extensions/conftest.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2025-2026 Zensical and contributors
+
+# SPDX-License-Identifier: MIT
+# All contributions are certified under the DCO
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from markdown import Markdown
+
+from zensical.config import DEFAULT_MARKDOWN_EXTENSIONS, _apply_defaults
+from zensical.extensions.context import ContextExtension, Page
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _expand_keys(data: dict[str, Any]) -> dict[str, Any]:
+    """Expand slash-separated keys in `data` into nested dicts, recursively.
+
+    `{"a/b/c": 1, "a/b/d": 2}` becomes `{"a": {"b": {"c": 1, "d": 2}}}`.
+    Keys with empty path segments (e.g. `"//"`) are left as-is.
+    Expansion is applied recursively to dict values.
+    """
+    result: dict[str, Any] = {}
+    for key, value in data.items():
+        parts = key.split("/")
+        if not all(parts):  # empty segment – treat whole key as literal
+            result[key] = value
+            continue
+        if isinstance(value, dict):
+            value = _expand_keys(value)  # noqa: PLW2901
+        node = result
+        for part in parts[:-1]:
+            node = node.setdefault(part, {})
+        node[parts[-1]] = value
+    return result
+
+
+def _deep_merge(base: Any, override: Any) -> Any:
+    """Recursively merge `override` into `base`.
+
+    Dicts are merged key-by-key; all other types are replaced by the override
+    value. When `override` is `None`, `base` is returned unchanged.
+    """
+    if override is None:
+        return base
+    if isinstance(base, dict) and isinstance(override, dict):
+        result = dict(base)
+        for key, value in override.items():
+            result[key] = _deep_merge(result.get(key), value)
+        return result
+    return override
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="base_configs", scope="session")
+def _fixture_base_configs(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> dict[str, Any]:
+    """Pre-compute both base configs through `_apply_defaults` once per session.
+
+    Individual fixtures deep-copy from here, so every test gets a fresh,
+    fully-processed config without re-running the expensive defaults pipeline.
+    """
+    root = tmp_path_factory.mktemp("conftest_base")
+    (root / "docs").mkdir()
+    path = str(root / "zensical.toml")
+
+    minimal = _apply_defaults(
+        {"site_name": "Demo", "markdown_extensions": {}},
+        path,
+    )
+    recommended = _apply_defaults(
+        {
+            "site_name": "Demo",
+            "markdown_extensions": DEFAULT_MARKDOWN_EXTENSIONS,
+        },
+        path,
+    )
+    return {"minimal": minimal, "recommended": recommended}
+
+
+@pytest.fixture(
+    name="config",
+    params=[
+        pytest.param("minimal", id="minimal_markdown"),
+        pytest.param("recommended", id="recommended_markdown"),
+    ],
+)
+def _fixture_config(
+    request: pytest.FixtureRequest,
+    base_configs: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a fresh deep copy of the pre-processed config for this variant."""
+    return copy.deepcopy(base_configs[request.param])
+
+
+@pytest.fixture(name="md")
+def _fixture_md(
+    config: dict[str, Any],
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+) -> Markdown:
+    """Return a Markdown instance configured from the active project config."""
+    # Always root the config at this test's tmp directory.
+    config["root_dir"] = str(tmp_path)
+
+    # Check test parametrization.
+    fixture_param = getattr(request, "param", {})
+    allowed_keys = {"page", "config"}
+    unexpected_keys = set(fixture_param) - allowed_keys
+    if unexpected_keys:
+        raise ValueError(
+            f"Unsupported md fixture params: {sorted(unexpected_keys)}. "
+            "Use only 'page' and 'config'."
+        )
+
+    # Apply test-specific config overrides.
+    if "config" in fixture_param:
+        expanded = _expand_keys(fixture_param["config"])
+
+        # Markdown extension overrides are handled separately because the
+        # processed config stores them as a list + mdx_configs dict, not as
+        # the nested dict that test params supply.
+        md_ext_overrides: dict[str, Any] = expanded.pop(
+            "markdown_extensions", {}
+        )
+
+        # Deep-merge all remaining overrides into the processed config.
+        for key, value in expanded.items():
+            config[key] = _deep_merge(config.get(key), value)
+
+        # Add/override individual extensions.
+        for ext_name, ext_cfg in md_ext_overrides.items():
+            if ext_name not in config["markdown_extensions"]:
+                config["markdown_extensions"].append(ext_name)
+            config["mdx_configs"][ext_name] = _deep_merge(
+                config["mdx_configs"].get(ext_name, {}),
+                ext_cfg or {},
+            )
+
+    # Instantiate Markdown parser from the processed extension list and configs.
+    md = Markdown(
+        extensions=list(config["markdown_extensions"]),
+        extension_configs=dict(config["mdx_configs"]),
+    )
+
+    # Register the rendering context extension.
+    base_page: dict[str, Any] = {"url": "/", "path": "index.md"}
+    page_overrides = fixture_param.get("page", {})
+    page = Page(**{**base_page, **page_overrides})
+    context_extension = ContextExtension(page=page, config=config)
+    context_extension.extendMarkdown(md)
+
+    return md

--- a/python/tests/unit/extensions/test_glightbox.py
+++ b/python/tests/unit/extensions/test_glightbox.py
@@ -23,91 +23,27 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from markdown import Markdown
 
-from zensical.extensions.emoji import to_svg, twemoji
-from zensical.extensions.glightbox import GlightboxExtension
+if TYPE_CHECKING:
+    from markdown import Markdown
 
-MINIMAL_EXTENSIONS = {"attr_list": {}}
-
-RECOMMENDED_EXTENSIONS = {
-    "abbr": {},
-    "admonition": {},
-    "attr_list": {},
-    "def_list": {},
-    "footnotes": {},
-    "md_in_html": {},
-    "toc": {"permalink": True},
-    "pymdownx.arithmatex": {"generic": True},
-    "pymdownx.betterem": {},
-    "pymdownx.caret": {},
-    "pymdownx.details": {},
-    "pymdownx.emoji": {
-        "emoji_generator": to_svg,
-        "emoji_index": twemoji,
-    },
-    "pymdownx.highlight": {
-        "anchor_linenums": True,
-        "line_spans": "__span",
-        "pygments_lang_class": True,
-    },
-    "pymdownx.inlinehilite": {},
-    "pymdownx.keys": {},
-    "pymdownx.magiclink": {},
-    "pymdownx.mark": {},
-    "pymdownx.smartsymbols": {},
-    "pymdownx.superfences": {
-        "custom_fences": [{"name": "mermaid", "class": "mermaid"}]
-    },
-    "pymdownx.tabbed": {
-        "alternate_style": True,
-        "combine_header_slug": True,
-    },
-    "pymdownx.tasklist": {"custom_checkbox": True},
-    "pymdownx.tilde": {},
-}
-
-_ACTIVE_EXTENSIONS = dict(MINIMAL_EXTENSIONS)
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
-def _make_md(
-    extensions: dict[str, Any] | None = None,
-    **kwargs: object,
-) -> Markdown:
-    """Return a Markdown instance with GlightboxExtension registered."""
-    extensions = dict(extensions or MINIMAL_EXTENSIONS)
-    md = Markdown(
-        extensions=list(extensions.keys()), extension_configs=extensions
-    )
-    GlightboxExtension(**kwargs).extendMarkdown(md)
-    return md
-
-
-def _convert(source: str, **kwargs: object) -> str:
-    return _make_md(extensions=_ACTIVE_EXTENSIONS, **kwargs).convert(source)
-
-
-@pytest.fixture(name="minimal_markdown")
-def _fixture_minimal_markdown() -> dict[str, Any]:
-    return dict(MINIMAL_EXTENSIONS)
-
-
-@pytest.fixture(name="recommended_markdown")
-def _fixture_recommended_markdown() -> dict[str, Any]:
-    return dict(RECOMMENDED_EXTENSIONS)
-
-
-@pytest.fixture(
-    params=["minimal_markdown", "recommended_markdown"],
-    ids=["minimal_markdown", "recommended_markdown"],
-    autouse=True,
-)
-def _active_markdown(request: pytest.FixtureRequest) -> None:
-    global _ACTIVE_EXTENSIONS  # noqa: PLW0603
-    _ACTIVE_EXTENSIONS = dict(request.getfixturevalue(request.param))
+def _glightbox(**kwargs: object) -> dict[str, Any]:
+    """Return md-fixture params with GlightboxExtension configured."""
+    return {
+        "config": {
+            "markdown_extensions": {
+                "zensical.extensions.glightbox": dict(kwargs),
+            }
+        }
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -115,29 +51,46 @@ def _active_markdown(request: pytest.FixtureRequest) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_image_is_wrapped_in_glightbox_anchor() -> None:
-    result = _convert("![alt](image.png)")
-    assert '<a class="glightbox"' in result
-    assert 'href="image.png"' in result
-    assert 'data-type="image"' in result
-    assert "<img" in result
+class TestBasicWrapping:
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_image_wrapped_in_anchor(self, md: Markdown) -> None:
+        result = md.convert("![alt](image.png)")
+        assert '<a class="glightbox"' in result
+        assert 'href="image.png"' in result
+        assert 'data-type="image"' in result
+        assert "<img" in result
 
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_anchor_contains_img(self, md: Markdown) -> None:
+        result = md.convert("![alt](image.png)")
+        assert result.index('<a class="glightbox"') < result.index("<img")
 
-def test_anchor_wraps_img_not_standalone() -> None:
-    result = _convert("![alt](image.png)")
-    # The <a> must contain the <img>
-    assert result.index('<a class="glightbox"') < result.index("<img")
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_src_used_as_href(self, md: Markdown) -> None:
+        result = md.convert("![](photo.jpg)")
+        assert 'href="photo.jpg"' in result
 
-
-def test_image_src_used_as_href() -> None:
-    result = _convert("![](photo.jpg)")
-    assert 'href="photo.jpg"' in result
-
-
-def test_image_with_title_attribute() -> None:
-    result = _convert('![alt](image.png "My Title")')
-    assert "<img" in result
-    assert 'href="image.png"' in result
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_with_title_attribute(self, md: Markdown) -> None:
+        result = md.convert('![alt](image.png "My Title")')
+        assert "<img" in result
+        assert 'href="image.png"' in result
 
 
 # ---------------------------------------------------------------------------
@@ -145,23 +98,44 @@ def test_image_with_title_attribute() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("cls", ["emojione", "twemoji", "gemoji", "off-glb"])
-def test_builtin_skip_classes_prevent_wrapping(cls: str) -> None:
-    result = _convert(f'<img src="img.png" class="{cls}" />')
-    assert '<a class="glightbox"' not in result
-
-
-def test_custom_skip_class_prevents_wrapping() -> None:
-    result = _convert(
-        '<img src="img.png" class="no-lightbox" />',
-        skip_classes=["no-lightbox"],
+class TestSkipClasses:
+    @pytest.mark.parametrize(
+        ("md", "cls"),
+        [
+            pytest.param(_glightbox(), "emojione", id="emojione"),
+            pytest.param(_glightbox(), "twemoji", id="twemoji"),
+            pytest.param(_glightbox(), "gemoji", id="gemoji"),
+            pytest.param(_glightbox(), "off-glb", id="off_glb"),
+        ],
+        indirect=["md"],
     )
-    assert '<a class="glightbox"' not in result
+    def test_builtin_skip_class_prevents_wrapping(
+        self, md: Markdown, cls: str
+    ) -> None:
+        result = md.convert(f'<img src="image.png" class="{cls}" />')
+        assert '<a class="glightbox"' not in result
 
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                _glightbox(skip_classes=["no-lightbox"]), id="custom_skip"
+            )
+        ],
+        indirect=["md"],
+    )
+    def test_custom_skip_class_prevents_wrapping(self, md: Markdown) -> None:
+        result = md.convert('<img src="image.png" class="no-lightbox" />')
+        assert '<a class="glightbox"' not in result
 
-def test_non_skip_class_is_wrapped() -> None:
-    result = _convert('<img src="img.png" class="hero" />')
-    assert '<a class="glightbox"' in result
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_non_skip_class_is_wrapped(self, md: Markdown) -> None:
+        result = md.convert('<img src="image.png" class="hero" />')
+        assert '<a class="glightbox"' in result
 
 
 # ---------------------------------------------------------------------------
@@ -169,40 +143,61 @@ def test_non_skip_class_is_wrapped() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_manual_mode_skips_plain_images() -> None:
-    result = _convert("![alt](image.png)", auto=False)
-    assert '<a class="glightbox"' not in result
-
-
-def test_manual_mode_wraps_on_glb_images() -> None:
-    result = _convert('<img src="image.png" class="on-glb" />', auto=False)
-    assert '<a class="glightbox"' in result
-
-
-# ---------------------------------------------------------------------------
-# auto_caption
-# ---------------------------------------------------------------------------
-
-
-def test_auto_caption_uses_alt_as_title() -> None:
-    result = _convert("![My Caption](image.png)", auto_caption=True)
-    assert 'data-title="My Caption"' in result
-
-
-def test_auto_caption_disabled_by_default() -> None:
-    result = _convert("![My Caption](image.png)")
-    assert "data-title" not in result
-
-
-def test_explicit_data_title_takes_precedence_over_auto_caption() -> None:
-    # data-title on img (via raw HTML) should survive auto_caption=True
-    result = _convert(
-        '<img src="image.png" alt="alt" data-title="Override" />',
-        auto_caption=True,
+class TestManualMode:
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(auto=False), id="auto_off")],
+        indirect=["md"],
     )
-    assert 'data-title="Override"' in result
-    # alt should not overwrite the explicit title
-    assert result.count("data-title=") == 1
+    def test_skips_plain_images(self, md: Markdown) -> None:
+        result = md.convert("![alt](image.png)")
+        assert '<a class="glightbox"' not in result
+
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(auto=False), id="auto_off")],
+        indirect=["md"],
+    )
+    def test_wraps_on_glb_images(self, md: Markdown) -> None:
+        result = md.convert('<img src="image.png" class="on-glb" />')
+        assert '<a class="glightbox"' in result
+
+
+# ---------------------------------------------------------------------------
+# Auto caption
+# ---------------------------------------------------------------------------
+
+
+class TestAutoCaption:
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(auto_caption=True), id="auto_caption_on")],
+        indirect=["md"],
+    )
+    def test_uses_alt_as_title(self, md: Markdown) -> None:
+        result = md.convert("![My Caption](image.png)")
+        assert 'data-title="My Caption"' in result
+
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_disabled_by_default(self, md: Markdown) -> None:
+        result = md.convert("![My Caption](image.png)")
+        assert "data-title" not in result
+
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(auto_caption=True), id="auto_caption_on")],
+        indirect=["md"],
+    )
+    def test_explicit_data_title_takes_precedence(self, md: Markdown) -> None:
+        result = md.convert(
+            '<img src="image.png" alt="alt" data-title="Override" />',
+        )
+        assert 'data-title="Override"' in result
+        assert result.count("data-title=") == 1
 
 
 # ---------------------------------------------------------------------------
@@ -210,15 +205,26 @@ def test_explicit_data_title_takes_precedence_over_auto_caption() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_default_caption_position_via_raw_html() -> None:
-    # caption_position on the image element itself is forwarded to the anchor
-    result = _convert('<img src="image.png" data-caption-position="top" />')
-    assert 'data-desc-position="top"' in result
+class TestCaptionPosition:
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_caption_position_forwarded_from_img(self, md: Markdown) -> None:
+        result = md.convert(
+            '<img src="image.png" data-caption-position="top" />'
+        )
+        assert 'data-desc-position="top"' in result
 
-
-def test_no_caption_position_by_default() -> None:
-    result = _convert("![alt](image.png)")
-    assert "data-desc-position" not in result
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_no_position_by_default(self, md: Markdown) -> None:
+        result = md.convert("![alt](image.png)")
+        assert "data-desc-position" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -226,40 +232,83 @@ def test_no_caption_position_by_default() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_width_and_height_are_forwarded() -> None:
-    result = _convert("![alt](image.png)", width="800px", height="600px")
-    assert 'data-width="800px"' in result
-    assert 'data-height="600px"' in result
+class TestWidthHeight:
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                _glightbox(width="800px", height="600px"),
+                id="explicit_dimensions",
+            )
+        ],
+        indirect=["md"],
+    )
+    def test_width_and_height_forwarded(self, md: Markdown) -> None:
+        result = md.convert("![alt](image.png)")
+        assert 'data-width="800px"' in result
+        assert 'data-height="600px"' in result
 
-
-def test_default_auto_width_height_are_omitted() -> None:
-    result = _convert("![alt](image.png)")
-    assert "data-width" not in result
-    assert "data-height" not in result
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_auto_dimensions_omitted(self, md: Markdown) -> None:
+        result = md.convert("![alt](image.png)")
+        assert "data-width" not in result
+        assert "data-height" not in result
 
 
 # ---------------------------------------------------------------------------
-# auto_themed gallery grouping
+# Auto-themed gallery grouping
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    ("src", "expected_gallery"),
-    [
-        ("image.png#only-light", "light"),
-        ("image.png#gh-light-mode-only", "light"),
-        ("image.png#only-dark", "dark"),
-        ("image.png#gh-dark-mode-only", "dark"),
-    ],
-)
-def test_auto_themed_gallery_grouping(src: str, expected_gallery: str) -> None:
-    result = _convert(f"![alt]({src})", auto_themed=True)
-    assert f'data-gallery="{expected_gallery}"' in result
+class TestAutoThemedGalleryGrouping:
+    @pytest.mark.parametrize(
+        ("md", "src", "expected_gallery"),
+        [
+            pytest.param(
+                _glightbox(auto_themed=True),
+                "image.png#only-light",
+                "light",
+                id="only_light",
+            ),
+            pytest.param(
+                _glightbox(auto_themed=True),
+                "image.png#gh-light-mode-only",
+                "light",
+                id="gh_light_mode_only",
+            ),
+            pytest.param(
+                _glightbox(auto_themed=True),
+                "image.png#only-dark",
+                "dark",
+                id="only_dark",
+            ),
+            pytest.param(
+                _glightbox(auto_themed=True),
+                "image.png#gh-dark-mode-only",
+                "dark",
+                id="gh_dark_mode_only",
+            ),
+        ],
+        indirect=["md"],
+    )
+    def test_gallery_grouping(
+        self, md: Markdown, src: str, expected_gallery: str
+    ) -> None:
+        result = md.convert(f"![alt]({src})")
+        assert f'data-gallery="{expected_gallery}"' in result
 
-
-def test_auto_themed_disabled_no_gallery() -> None:
-    result = _convert("![alt](image.png#only-light)")
-    assert "data-gallery" not in result
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_no_gallery_when_disabled(self, md: Markdown) -> None:
+        result = md.convert("![alt](image.png#only-light)")
+        assert "data-gallery" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -267,12 +316,16 @@ def test_auto_themed_disabled_no_gallery() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parsed_image_inside_anchor_is_not_double_wrapped() -> None:
-    # When Markdown parses an image link ([![]()]()), the treeprocessor sees
-    # the parent as an <a> and skips wrapping
-    result = _convert("[![alt](image.png)](https://example.com)")
-    assert 'class="glightbox"' not in result
-    assert 'href="https://example.com"' in result
+class TestImageInsideAnchor:
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_not_double_wrapped(self, md: Markdown) -> None:
+        result = md.convert("[![alt](image.png)](https://example.com)")
+        assert 'class="glightbox"' not in result
+        assert 'href="https://example.com"' in result
 
 
 # ---------------------------------------------------------------------------
@@ -280,14 +333,22 @@ def test_parsed_image_inside_anchor_is_not_double_wrapped() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_raw_html_image_is_wrapped() -> None:
-    # Raw HTML images bypass the treeprocessor and are handled by the
-    # postprocessor; markdown=1 block forces raw-HTML stashing
-    result = _convert('<img src="raw.png" />')
-    assert '<a class="glightbox"' in result
-    assert 'href="raw.png"' in result
+class TestPostprocessor:
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_raw_html_image_wrapped(self, md: Markdown) -> None:
+        result = md.convert('<img src="raw.png" />')
+        assert '<a class="glightbox"' in result
+        assert 'href="raw.png"' in result
 
-
-def test_raw_html_skip_class_not_wrapped() -> None:
-    result = _convert('<img src="raw.png" class="off-glb" />')
-    assert 'class="glightbox"' not in result
+    @pytest.mark.parametrize(
+        "md",
+        [pytest.param(_glightbox(), id="default")],
+        indirect=["md"],
+    )
+    def test_raw_html_skip_class_not_wrapped(self, md: Markdown) -> None:
+        result = md.convert('<img src="raw.png" class="off-glb" />')
+        assert 'class="glightbox"' not in result

--- a/python/tests/unit/extensions/test_macros.py
+++ b/python/tests/unit/extensions/test_macros.py
@@ -23,26 +23,17 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
-from markdown import Markdown
 
-from zensical.extensions.context import (
-    ContextExtension,
-    ContextPreprocessor,
-    Page,
-)
-from zensical.extensions.emoji import to_svg, twemoji
+from zensical.extensions.context import ContextPreprocessor
 from zensical.extensions.macros import (
     MacroEnv,
-    MacrosExtension,
     _fix_url,
-    _format_value,
     _load_module,
     _load_one_yaml,
-    _make_table,
     _merge_include_yaml,
     _pretty,
 )
@@ -50,390 +41,405 @@ from zensical.extensions.macros import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-
-MINIMAL_EXTENSIONS = {}
-
-RECOMMENDED_EXTENSIONS = {
-    "abbr": {},
-    "admonition": {},
-    "attr_list": {},
-    "def_list": {},
-    "footnotes": {},
-    "md_in_html": {},
-    "toc": {"permalink": True},
-    "pymdownx.arithmatex": {"generic": True},
-    "pymdownx.betterem": {},
-    "pymdownx.caret": {},
-    "pymdownx.details": {},
-    "pymdownx.emoji": {
-        "emoji_generator": to_svg,
-        "emoji_index": twemoji,
-    },
-    "pymdownx.highlight": {
-        "anchor_linenums": True,
-        "line_spans": "__span",
-        "pygments_lang_class": True,
-    },
-    "pymdownx.inlinehilite": {},
-    "pymdownx.keys": {},
-    "pymdownx.magiclink": {},
-    "pymdownx.mark": {},
-    "pymdownx.smartsymbols": {},
-    "pymdownx.superfences": {
-        "custom_fences": [{"name": "mermaid", "class": "mermaid"}]
-    },
-    "pymdownx.tabbed": {
-        "alternate_style": True,
-        "combine_header_slug": True,
-    },
-    "pymdownx.tasklist": {"custom_checkbox": True},
-    "pymdownx.tilde": {},
-}
+    from markdown import Markdown
 
 
-def _page(meta: dict[str, Any] | None = None) -> dict[str, Any]:
-    return {
-        "url": "/",
-        "path": "index.md",
-        "meta": dict(meta or {}),
-    }
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
 
 
-@pytest.fixture(
-    name="project_config",
-    params=[MINIMAL_EXTENSIONS, RECOMMENDED_EXTENSIONS],
-    ids=["minimal_markdown", "recommended_markdown"],
-)
-def _fixture_project_config(request: pytest.FixtureRequest) -> dict[str, Any]:
-    active_markdown = dict(request.param)
-    return {"site_name": "Demo", "markdown_extensions": active_markdown}
+class TestFilters:
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            pytest.param("page.html", "../page.html", id="relative_html"),
+            pytest.param(
+                "assets/image.png", "../assets/image.png", id="relative_asset"
+            ),
+            pytest.param(
+                "https://example.org",
+                "https://example.org",
+                id="absolute_https",
+            ),
+            pytest.param(
+                "mailto:test@example.org",
+                "mailto:test@example.org",
+                id="mailto",
+            ),
+        ],
+    )
+    def test_fix_url(self, url: str, expected: str) -> None:
+        assert _fix_url(url) == expected
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            pytest.param(
+                [("alpha", "str", "hello")],
+                "**alpha** | *str* | hello",
+                id="single_row",
+            ),
+            pytest.param([], "", id="empty"),
+        ],
+    )
+    def test_pretty(
+        self, payload: list[tuple[str, str, str]], expected: str
+    ) -> None:
+        output = _pretty(payload)
+        if expected:
+            assert expected in output
+        else:
+            assert output == ""
 
 
-@pytest.fixture(name="md")
-def _fixture_md(
-    project_config: dict[str, Any],
-    request: pytest.FixtureRequest,
-    tmp_path: Path,
-) -> Markdown:
-    """Return a Markdown instance with MacrosExtension registered."""
-    fixture_param = dict(getattr(request, "param", {}))
-    allowed_keys = {"macros", "page", "project_config"}
-    unexpected_keys = set(fixture_param) - allowed_keys
-    if unexpected_keys:
-        raise ValueError(
-            f"Unsupported md fixture params: {sorted(unexpected_keys)}. "
-            "Use only 'macros', 'page', and 'project_config'."
+# ---------------------------------------------------------------------------
+# Defining environments
+# ---------------------------------------------------------------------------
+
+
+class TestMacroEnv:
+    def test_registers_macros_and_filters(self) -> None:
+        env = MacroEnv()
+
+        @env.macro
+        def twice(value: int) -> int:
+            return value * 2
+
+        @env.filter(name="rev")
+        def reverse(value: str) -> str:
+            return value[::-1]
+
+        assert env.macros["twice"](4) == 8
+        assert env.filters["rev"]("abc") == "cba"
+
+
+# ---------------------------------------------------------------------------
+# Loading YAML
+# ---------------------------------------------------------------------------
+
+
+class TestLoadYAML:
+    @pytest.mark.parametrize(
+        ("relative_path", "content", "expected"),
+        [
+            pytest.param(
+                "ok.yaml", "a: 1\nb: x\n", {"a": 1, "b": "x"}, id="valid_dict"
+            ),
+            pytest.param(
+                "not_dict.yaml", "- 1\n- 2\n", None, id="non_dict_returns_none"
+            ),
+        ],
+    )
+    def test_with_relative_paths(
+        self,
+        tmp_path: Path,
+        relative_path: str,
+        content: str,
+        expected: dict | None,
+    ) -> None:
+        (tmp_path / relative_path).write_text(content, encoding="utf-8")
+        loaded = _load_one_yaml(relative_path, tmp_path)
+        assert loaded == expected
+
+    def test_blocks_outside_project_root(self, tmp_path: Path) -> None:
+        outside = tmp_path.parent / "outside.yaml"
+        outside.write_text("x: 1\n", encoding="utf-8")
+        loaded = _load_one_yaml(str(outside), tmp_path)
+        assert loaded is None
+
+    @pytest.mark.parametrize(
+        "include_yaml",
+        [
+            pytest.param(["a.yaml", "b.yaml"], id="list"),
+            pytest.param({"left": "a.yaml", "right": "b.yaml"}, id="dict"),
+        ],
+    )
+    def test_merge_include(
+        self,
+        tmp_path: Path,
+        include_yaml: list[str] | dict[str, str],
+    ) -> None:
+        (tmp_path / "a.yaml").write_text("x: 1\n", encoding="utf-8")
+        (tmp_path / "b.yaml").write_text("y: 2\n", encoding="utf-8")
+        variables: dict = {}
+        _merge_include_yaml(include_yaml, tmp_path, variables)
+        if isinstance(include_yaml, list):
+            assert variables == {"x": 1, "y": 2}
+        else:
+            assert variables == {"left": {"x": 1}, "right": {"y": 2}}
+
+
+# ---------------------------------------------------------------------------
+# Loading modules / pluglets
+# ---------------------------------------------------------------------------
+
+
+class TestLoadModule:
+    def test_from_local_file(self, tmp_path: Path) -> None:
+        (tmp_path / "main.py").write_text(
+            "def define_env(env):\n"
+            "    env.variables['site_name'] = 'Demo'\n"
+            "    @env.macro\n"
+            "    def twice(x):\n"
+            "        return x * 2\n"
+            "    @env.filter\n"
+            "    def shout(s):\n"
+            "        return s.upper()\n",
+            encoding="utf-8",
         )
-    macro_config = dict(fixture_param.get("macros", {}))
-    page = fixture_param.get("page", Page(url="/", path="index.md"))
-    if isinstance(page, dict):
-        page = Page(**page)
-    project_overrides = dict(fixture_param.get("project_config", {}))
-    effective_project_config = {**project_config, **project_overrides}
-    if "root_dir" not in effective_project_config:
-        effective_project_config["root_dir"] = str(tmp_path)
-    markdown_extensions = dict(
-        effective_project_config.get("markdown_extensions", {})
+        variables, macros, filters = _load_module("main", tmp_path)
+        assert variables["site_name"] == "Demo"
+        assert macros["twice"](3) == 6
+        assert filters["shout"]("hi") == "HI"
+
+    @pytest.mark.parametrize(
+        "module_name",
+        [
+            pytest.param("../evil", id="path_traversal"),
+            pytest.param("foo/bar", id="forward_slash"),
+            pytest.param("foo\\\\bar", id="backslash"),
+        ],
     )
-    md = Markdown(
-        extensions=list(markdown_extensions.keys()),
-        extension_configs=markdown_extensions,
+    def test_rejects_invalid_names(self, module_name: str) -> None:
+        assert _load_module(module_name) == ({}, {}, {})
+
+
+# ---------------------------------------------------------------------------
+# Markdown preprocessor
+# ---------------------------------------------------------------------------
+
+
+class TestPreprocessor:
+    @pytest.mark.parametrize(
+        ("md", "expected"),
+        [
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": False
+                            },
+                        },
+                    }
+                },
+                "<p>Value: {{ 1 + 1 }}</p>",
+                id="disabled_keeps_template",
+            ),
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": True
+                            },
+                        },
+                    }
+                },
+                "<p>Value: 2</p>",
+                id="enabled_renders",
+            ),
+        ],
+        indirect=["md"],
     )
-    ContextExtension(page=page, config=effective_project_config).extendMarkdown(
-        md
+    def test_respects_render_by_default(
+        self, md: Markdown, expected: str
+    ) -> None:
+        source = "Value: {{ 1 + 1 }}"
+        assert md.convert(source) == expected
+
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": False
+                            },
+                        },
+                    },
+                    "page": {"meta": {"render_macros": True}},
+                },
+                id="page_opt_in",
+            ),
+        ],
+        indirect=["md"],
     )
-    MacrosExtension(**macro_config).extendMarkdown(md)
-    return md
+    def test_renders_when_opted_in_by_page_meta(self, md: Markdown) -> None:
+        assert md.convert("Value: {{ 1 + 1 }}") == "<p>Value: 2</p>"
 
-
-@pytest.mark.parametrize(
-    ("url", "expected"),
-    [
-        ("page.html", "../page.html"),
-        ("assets/img.png", "../assets/img.png"),
-        ("https://example.org", "https://example.org"),
-        ("mailto:test@example.org", "mailto:test@example.org"),
-    ],
-)
-def test_fix_url(url: str, expected: str) -> None:
-    assert _fix_url(url) == expected
-
-
-def test_macro_env_registers_macros_and_filters() -> None:
-    env = MacroEnv()
-
-    @env.macro
-    def twice(value: int) -> int:
-        return value * 2
-
-    @env.filter(name="rev")
-    def reverse(value: str) -> str:
-        return value[::-1]
-
-    assert env.macros["twice"](4) == 8
-    assert env.filters["rev"]("abc") == "cba"
-
-
-@pytest.mark.parametrize(
-    ("payload", "expected"),
-    [
-        ([("alpha", "str", "hello")], "**alpha** | *str* | hello"),
-        ([], ""),
-    ],
-)
-def test_pretty(payload: list[tuple[str, str, str]], expected: str) -> None:
-    output = _pretty(payload)
-    if expected:
-        assert expected in output
-    else:
-        assert output == ""
-
-
-def test_make_table_escapes_pipe() -> None:
-    table = _make_table(
-        rows=[("left|right", "type", "a|b")],
-        header=("Variable", "Type", "Content"),
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": True,
+                                "include_yaml": ["vars.yaml"],
+                                "module_name": "main",
+                            },
+                        },
+                        "extra/who": "world",
+                    },
+                    "page": {"meta": {"render_macros": True}},
+                },
+                id="include_yaml_and_module",
+            ),
+        ],
+        indirect=["md"],
     )
-    assert "left\\|right" in table
-    assert "a\\|b" in table
+    def test_renders_with_include_yaml_and_module(
+        self,
+        md: Markdown,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "vars.yaml").write_text("name: Ada\n", encoding="utf-8")
+        (tmp_path / "main.py").write_text(
+            "def define_env(env):\n"
+            "    @env.macro\n"
+            "    def greet(name):\n"
+            "        return f'Hello {name}!'\n",
+            encoding="utf-8",
+        )
+        rendered = md.convert("{{ greet(name) }}\n\n{{ who }}")
+        assert "Hello Ada!" in rendered
+        assert "world" in rendered
 
-
-def test_format_value_for_callable_and_dict() -> None:
-    def sample(name: str) -> str:
-        """Doc first line.\nIgnored."""
-        return name
-
-    class Obj:
-        pass
-
-    value = {
-        "count": 1,
-        "name": "hello",
-        "obj": Obj(),
-    }
-
-    rendered_callable = _format_value(sample)
-    rendered_dict = _format_value(value)
-
-    assert "(*name*)" in rendered_callable
-    assert "Doc first line." in rendered_callable
-    assert "**count** = 1" in rendered_dict
-    assert "**obj** [*Obj*]" in rendered_dict
-
-
-@pytest.mark.parametrize(
-    ("relative_path", "content", "expected"),
-    [
-        ("ok.yaml", "a: 1\nb: x\n", {"a": 1, "b": "x"}),
-        ("not_dict.yaml", "- 1\n- 2\n", None),
-    ],
-)
-def test_load_one_yaml_with_relative_paths(
-    tmp_path: Path,
-    relative_path: str,
-    content: str,
-    expected: dict | None,
-) -> None:
-    (tmp_path / relative_path).write_text(content, encoding="utf-8")
-    loaded = _load_one_yaml(relative_path, tmp_path)
-    assert loaded == expected
-
-
-def test_load_one_yaml_blocks_outside_project_root(tmp_path: Path) -> None:
-    outside = tmp_path.parent / "outside.yaml"
-    outside.write_text("x: 1\n", encoding="utf-8")
-    loaded = _load_one_yaml(str(outside), tmp_path)
-    assert loaded is None
-
-
-@pytest.mark.parametrize(
-    "include_yaml",
-    [
-        ["a.yaml", "b.yaml"],
-        {"left": "a.yaml", "right": "b.yaml"},
-    ],
-)
-def test_merge_include_yaml_list_and_dict(
-    tmp_path: Path,
-    include_yaml: list[str] | dict[str, str],
-) -> None:
-    (tmp_path / "a.yaml").write_text("x: 1\n", encoding="utf-8")
-    (tmp_path / "b.yaml").write_text("y: 2\n", encoding="utf-8")
-    variables: dict = {}
-    _merge_include_yaml(include_yaml, tmp_path, variables)
-    if isinstance(include_yaml, list):
-        assert variables == {"x": 1, "y": 2}
-    else:
-        assert variables == {"left": {"x": 1}, "right": {"y": 2}}
-
-
-def test_load_module_from_local_file(tmp_path: Path) -> None:
-    (tmp_path / "main.py").write_text(
-        "def define_env(env):\n"
-        "    env.variables['site_name'] = 'Demo'\n"
-        "    @env.macro\n"
-        "    def twice(x):\n"
-        "        return x * 2\n"
-        "    @env.filter\n"
-        "    def shout(s):\n"
-        "        return s.upper()\n",
-        encoding="utf-8",
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": True
+                            },
+                        },
+                    }
+                },
+                id="render_by_default",
+            ),
+        ],
+        indirect=["md"],
     )
-    variables, macros, filters = _load_module("main", tmp_path)
-    assert variables["site_name"] == "Demo"
-    assert macros["twice"](3) == 6
-    assert filters["shout"]("hi") == "HI"
+    def test_error_handling_keep_text_by_default(self, md: Markdown) -> None:
+        assert "{{ not_closed" in md.convert("{{ not_closed")
 
-
-@pytest.mark.parametrize("module_name", ["../evil", "foo/bar", r"foo\\bar"])
-def test_load_module_rejects_non_package_like_module_names(
-    module_name: str,
-) -> None:
-    assert _load_module(module_name) == ({}, {}, {})
-
-
-@pytest.mark.parametrize(
-    ("md", "expected"),
-    [
-        ({"macros": {"render_by_default": False}}, "<p>Value: {{ 1 + 1 }}</p>"),
-        ({"macros": {"render_by_default": True}}, "<p>Value: 2</p>"),
-    ],
-    indirect=["md"],
-)
-def test_preprocessor_respects_render_by_default(
-    md: Markdown, expected: str
-) -> None:
-    source = "Value: {{ 1 + 1 }}"
-    assert md.convert(source) == expected
-
-
-@pytest.mark.parametrize(
-    "md",
-    [
-        {
-            "macros": {"render_by_default": False},
-            "page": _page({"render_macros": True}),
-        },
-    ],
-    indirect=True,
-)
-def test_preprocessor_renders_when_opted_in_by_page_meta(md: Markdown) -> None:
-    assert md.convert("Value: {{ 1 + 1 }}") == "<p>Value: 2</p>"
-
-
-@pytest.mark.parametrize(
-    "md",
-    [
-        {
-            "macros": {
-                "render_by_default": True,
-                "include_yaml": ["vars.yaml"],
-                "module_name": "main",
-            },
-            "page": _page({"render_macros": True}),
-            "project_config": {"extra": {"who": "world"}},
-        },
-    ],
-    indirect=True,
-)
-def test_preprocessor_renders_with_include_yaml_and_module(
-    md: Markdown,
-    tmp_path: Path,
-) -> None:
-    (tmp_path / "vars.yaml").write_text("name: Ada\n", encoding="utf-8")
-    (tmp_path / "main.py").write_text(
-        "def define_env(env):\n"
-        "    @env.macro\n"
-        "    def greet(name):\n"
-        "        return f'Hello {name}!'\n",
-        encoding="utf-8",
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": True,
+                                "on_error_fail": True,
+                            },
+                        },
+                    }
+                },
+                id="on_error_fail",
+            ),
+        ],
+        indirect=["md"],
     )
-    rendered = md.convert("{{ greet(name) }}\n\n{{ who }}")
-    assert "Hello Ada!" in rendered
-    assert "world" in rendered
+    def test_error_handling_raises_when_enabled(self, md: Markdown) -> None:
+        with pytest.raises(TemplateSyntaxError):
+            md.convert("{{ not_closed")
 
-
-@pytest.mark.parametrize(
-    "md",
-    [{"macros": {"render_by_default": True}}],
-    indirect=True,
-)
-def test_preprocessor_error_handling_keep_text_by_default(md: Markdown) -> None:
-    assert "{{ not_closed" in md.convert("{{ not_closed")
-
-
-@pytest.mark.parametrize(
-    "md",
-    [{"macros": {"render_by_default": True, "on_error_fail": True}}],
-    indirect=True,
-)
-def test_preprocessor_error_handling_raises_when_enabled(md: Markdown) -> None:
-    with pytest.raises(TemplateSyntaxError):
-        md.convert("{{ not_closed")
-
-
-@pytest.mark.parametrize(
-    "md",
-    [
-        {
-            "macros": {"render_by_default": True},
-            "page": _page({"render_macros": True, "title": "Doc {{ 2 + 3 }}"}),
-        },
-    ],
-    indirect=True,
-)
-def test_preprocessor_renders_jinja_in_title_meta(md: Markdown) -> None:
-    md.convert("# {{ title }}")
-    context = ContextPreprocessor.from_markdown(md)
-    assert context is not None
-    assert context.page.meta["title"] == "Doc 5"
-
-
-@pytest.mark.parametrize(
-    "md",
-    [
-        {
-            "macros": {
-                "render_by_default": True,
-                "on_undefined": "strict",
-                "on_error_fail": True,
-            },
-        }
-    ],
-    indirect=True,
-)
-def test_preprocessor_strict_undefined_raises(md: Markdown) -> None:
-    with pytest.raises(UndefinedError):
-        md.convert("{{ missing_variable }}")
-
-
-@pytest.mark.parametrize(
-    "md",
-    [
-        {
-            "macros": {
-                "render_by_default": True,
-                "module_name": "main",
-            },
-            "project_config": {
-                "markdown_extensions": {"pymdownx.superfences": {}}
-            },
-        }
-    ],
-    indirect=True,
-)
-def test_macro_fenced_code_block_processed_by_superfences(
-    md: Markdown,
-    tmp_path: Path,
-) -> None:
-    """A macro that outputs a fenced code block is processed by superfences."""
-    (tmp_path / "main.py").write_text(
-        "def define_env(env):\n"
-        "    @env.macro\n"
-        "    def code_snippet(lang, code):\n"
-        "        return f'```{lang}\\n{code}\\n```\\n'\n",
-        encoding="utf-8",
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": True
+                            },
+                        },
+                    },
+                    "page": {
+                        "meta": {
+                            "render_macros": True,
+                            "title": "Doc {{ 2 + 3 }}",
+                        },
+                    },
+                },
+                id="jinja_in_title",
+            ),
+        ],
+        indirect=["md"],
     )
-    result = md.convert("{{ code_snippet('python', 'x = 1 + 1') }}")
-    assert "<code>python" not in result
-    assert "x = 1 + 1" not in result  # we expect spans
+    def test_renders_jinja_in_title_meta(self, md: Markdown) -> None:
+        md.convert("# {{ title }}")
+        context = ContextPreprocessor.from_markdown(md)
+        assert context is not None
+        assert context.page.meta["title"] == "Doc 5"
+
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": True,
+                                "on_undefined": "strict",
+                                "on_error_fail": True,
+                            },
+                        },
+                    },
+                },
+                id="strict_on_error_fail",
+            ),
+        ],
+        indirect=["md"],
+    )
+    def test_strict_undefined_raises(self, md: Markdown) -> None:
+        with pytest.raises(UndefinedError):
+            md.convert("{{ missing_variable }}")
+
+    @pytest.mark.parametrize(
+        "md",
+        [
+            pytest.param(
+                {
+                    "config": {
+                        "markdown_extensions": {
+                            "zensical.extensions.macros": {
+                                "render_by_default": True,
+                                "module_name": "main",
+                            },
+                            "pymdownx.superfences": {},
+                        },
+                    },
+                },
+                id="superfences",
+            ),
+        ],
+        indirect=["md"],
+    )
+    def test_fenced_code_block_processed_by_superfences(
+        self,
+        md: Markdown,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "main.py").write_text(
+            "def define_env(env):\n"
+            "    @env.macro\n"
+            "    def code_snippet(lang, code):\n"
+            "        return f'```{lang}\\n{code}\\n```\\n'\n",
+            encoding="utf-8",
+        )
+        result = md.convert("{{ code_snippet('python', 'x = 1 + 1') }}")
+        assert "<code>python" not in result
+        assert "x = 1 + 1" not in result  # we expect spans

--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -49,6 +49,7 @@ from zensical.extensions.emoji import to_svg, twemoji
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+
 # ----------------------------------------------------------------------------
 # Globals
 # ----------------------------------------------------------------------------
@@ -63,6 +64,50 @@ references to functions or other Python objects, for which we don't have any
 representation in Rust. Thus, we just keep the configuration on the Python
 side, and use it directly when needed. It's a hack but will do for now.
 """
+
+
+# ----------------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------------
+
+
+DEFAULT_MARKDOWN_EXTENSIONS = {
+    "abbr": {},
+    "admonition": {},
+    "attr_list": {},
+    "def_list": {},
+    "footnotes": {},
+    "md_in_html": {},
+    "toc": {"permalink": True},
+    "pymdownx.arithmatex": {"generic": True},
+    "pymdownx.betterem": {},
+    "pymdownx.caret": {},
+    "pymdownx.details": {},
+    "pymdownx.emoji": {
+        "emoji_generator": to_svg,
+        "emoji_index": twemoji,
+    },
+    "pymdownx.highlight": {
+        "anchor_linenums": True,
+        "line_spans": "__span",
+        "pygments_lang_class": True,
+    },
+    "pymdownx.inlinehilite": {},
+    "pymdownx.keys": {},
+    "pymdownx.magiclink": {},
+    "pymdownx.mark": {},
+    "pymdownx.smartsymbols": {},
+    "pymdownx.superfences": {
+        "custom_fences": [{"name": "mermaid", "class": "mermaid"}]
+    },
+    "pymdownx.tabbed": {
+        "alternate_style": True,
+        "combine_header_slug": True,
+    },
+    "pymdownx.tasklist": {"custom_checkbox": True},
+    "pymdownx.tilde": {},
+}
+
 
 # ----------------------------------------------------------------------------
 # Classes
@@ -446,45 +491,7 @@ def _apply_defaults(config: dict, path: str) -> dict:
     # decided to set defaults that make it easy to get started with sensible
     # Markdown support, but users can override this as needed.
     markdown_extensions, mdx_configs = _convert_markdown_extensions(
-        config.get(
-            "markdown_extensions",
-            {
-                "abbr": {},
-                "admonition": {},
-                "attr_list": {},
-                "def_list": {},
-                "footnotes": {},
-                "md_in_html": {},
-                "toc": {"permalink": True},
-                "pymdownx.arithmatex": {"generic": True},
-                "pymdownx.betterem": {},
-                "pymdownx.caret": {},
-                "pymdownx.details": {},
-                "pymdownx.emoji": {
-                    "emoji_generator": to_svg,
-                    "emoji_index": twemoji,
-                },
-                "pymdownx.highlight": {
-                    "anchor_linenums": True,
-                    "line_spans": "__span",
-                    "pygments_lang_class": True,
-                },
-                "pymdownx.inlinehilite": {},
-                "pymdownx.keys": {},
-                "pymdownx.magiclink": {},
-                "pymdownx.mark": {},
-                "pymdownx.smartsymbols": {},
-                "pymdownx.superfences": {
-                    "custom_fences": [{"name": "mermaid", "class": "mermaid"}]
-                },
-                "pymdownx.tabbed": {
-                    "alternate_style": True,
-                    "combine_header_slug": True,
-                },
-                "pymdownx.tasklist": {"custom_checkbox": True},
-                "pymdownx.tilde": {},
-            },
-        )
+        config.get("markdown_extensions", DEFAULT_MARKDOWN_EXTENSIONS)
     )
     config["markdown_extensions"] = markdown_extensions
     config["mdx_configs"] = mdx_configs
@@ -1028,6 +1035,8 @@ def _convert_plugins(value: Any, config: dict) -> dict:
 
 
 # ----------------------------------------------------------------------------
+
+
 def _yaml_load(source: IO) -> dict[str, Any]:
     """Load configuration file, resolve environment variables and parent files.
 


### PR DESCRIPTION
We use fixtures to allow extension tests to easily override parts of the project's configuration. Tests can then easily receive a pre-configured Markdown parser as argument, and use it convert Markdown to HTML and assert results. The rendering context extension is registered on the Markdown parser, giving access to a full config dict. We then use these new testing features into the existing glightbox/macros test modules.