### PR TITLE
fix: fix `IndexError` due to inline math scanning (#659)

### DIFF
--- a/python/tests/unit/collectors/test_references.py
+++ b/python/tests/unit/collectors/test_references.py
@@ -1672,6 +1672,9 @@ class TestMath:
         assert text(md, links[0].text) == b"before"
         assert text(md, links[0].href) == b"href"
 
+    def test_line_ending_with_dollar(self) -> None:
+        collect(b"text$")  # no IndexError
+
 
 # ---------------------------------------------------------------------------
 

--- a/python/zensical/collectors/references/cursor.py
+++ b/python/zensical/collectors/references/cursor.py
@@ -1021,12 +1021,14 @@ def _scan_inline_code(cursor: Cursor) -> int | None:
 def _scan_math_inline(cursor: Cursor) -> int | None:
     """Scan for `$...$` math."""
     end = cursor.pos
-    if end >= cursor.end and cursor.data[end] != _DOLLAR:
+
+    # Skip opening $ and abort if no more data
+    if end >= cursor.end and cursor.data[cursor.end - 1] != _DOLLAR:
         return None
 
     # Skip opening $ and abort if it's followed by whitespace or another $
     end += 1
-    if end >= cursor.end and (
+    if end < cursor.end and (
         cursor.data[end] in (_DOLLAR, _SPACE, _TAB, _NL, _CR)
     ):
         return None


### PR DESCRIPTION
Issue #659