### PR TITLE
feat: attach context on what file a cache write if something failed

### DIFF
--- a/crates/zensical/src/workflow/cached.rs
+++ b/crates/zensical/src/workflow/cached.rs
@@ -25,7 +25,7 @@
 
 //! Workflow cache.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::hash::{DefaultHasher, Hash, Hasher};
@@ -92,11 +92,13 @@ where
         }
     }
 
-    // Compute artifact and convert into report - note that we need to properly
-    // handle encoding and file I/O errors here as well
-    f(args).inspect(|data| {
-        serde_json::to_string_pretty(&Cached { data, hash })
-            .map(|content| fs::write(path, content).expect("invariant"))
-            .expect("invariant");
-    })
+    let data = f(args)?;
+    let content = serde_json::to_string_pretty(&Cached { data: &data, hash })
+        .with_context(|| {
+        format!("failed to serialize cache entry for {}", path.display())
+    })?;
+    fs::write(&path, content).with_context(|| {
+        format!("failed to write cache entry to {}", path.display())
+    })?;
+    Ok(data)
 }


### PR DESCRIPTION
## Summary

The error message for this panic is not really usefull.
By attaching context, it can be!

## Related issue

This pull request is linked to the following issue:
- Resolves https://github.com/zensical/zensical/issues/682

## Checklist

<!-- All boxes must be checked -->

Please ensure that your PR meets the following requirements:

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
