### PR TITLE
chore: release v0.0.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.41"
+version = "0.0.42"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.41"
+version = "0.0.42"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version includes a number of bug fixes and refactorings to improve the stability and accuracy of link validation, and fixes a reload loop when the `custom_dir`, which is auto-watched, is explicitly added to `watch`. Moreover, GLightbox is now only downloaded when needed, which fixes an issue when using Zensical in air-gapped environments.
