### PR TITLE
chore: release v0.0.43

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.42"
+version = "0.0.43"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.42"
+version = "0.0.43"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version fixes further edge cases in link validation, and adds support for UTF-8 encoding with byte-order-marks.
