### PR TITLE
fix: improve error message when missing icon is used (#708)

### DIFF
--- a/crates/zensical/src/lib.rs
+++ b/crates/zensical/src/lib.rs
@@ -132,6 +132,7 @@ fn clear_dir(dir: &Path) -> io::Result<()> {
 }
 
 /// Run the build process.
+#[allow(clippy::too_many_lines)]
 fn run(config_file: &PathBuf, mode: Mode) -> PyResult<bool> {
     #[cfg(feature = "tracing")]
     let _guard = setup_tracing();
@@ -280,6 +281,13 @@ fn run(config_file: &PathBuf, mode: Mode) -> PyResult<bool> {
     // Exit with error, if any
     if let Some(err) = maybe_err {
         println!("{err}");
+        // Walk the error source chain so the root cause (e.g. a missing icon
+        // name) is visible instead of only the outermost template error.
+        let mut cause: &dyn std::error::Error = &err;
+        while let Some(source) = cause.source() {
+            println!("  caused by: {source}");
+            cause = source;
+        }
         std::process::exit(1);
     }
 


### PR DESCRIPTION
Issue #708

We'll likely get more users migrating directly from Material for MkDocs, and they'll get this error when trying to include a now missing icon: 

```
could not render include: error in "partials/nav.html" (in base.html:172)
```

This PR updates the error message to:

```
could not render include: error in "partials/nav.html" (in base.html:172)
  caused by: template not found: tried to include non-existing template ".icons/fontawesome/solid/browser.svg" (in partials/nav-item.html:25)
```

This could impact other error messages. Maybe there's a way to improve this specific error only?