### PR TITLE
chore: upgrade pymdownx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "jinja2>=3.1",
     "markdown>=3.7",
     "pygments>=2.20",
-    "pymdown-extensions>=10.21.2",
+    "pymdown-extensions>=10.21.3",
     "pyyaml>=6.0.2",
     "tomli>=2.4.0",
 ]


### PR DESCRIPTION
Version 10.21.2 is affected by a CVE, see https://github.com/advisories/GHSA-jh85-wwv9-24hv.