### PR TITLE
fix: watch docs directory first to avoid empty site output

### DIFF
--- a/crates/zensical/src/watcher.rs
+++ b/crates/zensical/src/watcher.rs
@@ -225,7 +225,12 @@ impl Watcher {
             }
         });
 
-        // Watch docs and template directories
+        // Watch docs directory first, so docs files enter the scheduler
+        // before theme/config files. This ensures the build loop stays
+        // alive long enough for the barrier to collect all markdown pages.
+        agent.watch(config.get_docs_dir())?;
+
+        // Watch template directories
         agent.watch(&config.path)?;
         for theme_dir in &config.theme_dirs {
             // Skip `.icons` directory. On NetBSD, kqueue opens one file
@@ -257,9 +262,6 @@ impl Watcher {
         let site_dir = config.get_site_dir();
         fs::create_dir_all(&site_dir).unwrap();
         agent.watch(&site_dir)?;
-
-        // Return file watcher
-        agent.watch(config.get_docs_dir())?;
         Ok(Self { agent })
     }
 


### PR DESCRIPTION
Fixes #726. Related to #365 and #641.

## Problem

The docs directory was registered with the file agent last — after config, theme, and site directories. Because `agent.watch()` enqueues scan actions processed asynchronously (20 ms debounce), the config directory was always scanned first. Once `zensical.toml` entered the scheduler the build loop started, processed config/theme files, went empty, and exited before the docs directory was ever scanned.

Result: the markdown barrier (`wait_for_markdown`) never fired, `generate_nav` was never called, and `site/` contained only static assets — no HTML pages.

## Fix

Move `agent.watch(config.get_docs_dir())` to be the **first** watch call so that docs files enter the scheduler before any other file type, keeping the build loop alive until the barrier can fire.

The change is a single reordering of watch calls in `Watcher::new` with an updated comment explaining the invariant.