### PR TITLE
fix: revert "fix: brackets in indented code blocks recognized as unresolved link references (#700)"

### DIFF
--- a/python/tests/unit/collectors/test_references.py
+++ b/python/tests/unit/collectors/test_references.py
@@ -455,6 +455,7 @@ class TestLinkReferences:
             pytest.param(b"text [TOC]", id="inline"),
             pytest.param(b"[TOC] text", id="inline-prefix"),
             pytest.param(b"[TOC]\ntext", id="paragraph"),
+            pytest.param(b"    [TOC]", id="code-block"),
         ],
     )
     def test_link_ref_toc_text(self, md: bytes) -> None:
@@ -736,7 +737,10 @@ class TestLinkDefinitions:
     def test_no_link_def_indent(self) -> None:
         md = b"    [id]: href"
         refs = collect(md)
-        assert len(refs) == 0
+        assert len(refs) == 1
+
+        link_refs = link_refs_only(refs)
+        assert len(link_refs) == 1
 
     def test_no_link_def_prefix(self) -> None:
         md = b"text [id]: href"
@@ -1725,35 +1729,6 @@ class TestSnippets:
             b"# --8<-- [end:reference_section]\n"
             b"[after](href)\n"
         )
-        refs = collect(md)
-        assert len(refs) == 1
-
-        links = links_only(refs)
-        assert len(links) == 1
-        assert text(md, links[0].text) == b"after"
-        assert text(md, links[0].href) == b"href"
-
-
-# ---------------------------------------------------------------------------
-
-
-class TestIndentedCodeBlocks:
-    """Tests for indented code blocks."""
-
-    def test_indented_code_is_ignored(self) -> None:
-        md = b"\n    [Start][]\n"
-        refs = collect(md)
-        assert len(refs) == 0
-
-    def test_indented_code_with_blank_line_continuation_is_ignored(
-        self,
-    ) -> None:
-        md = b"\n    [Start][]\n\n    [End][]\n"
-        refs = collect(md)
-        assert len(refs) == 0
-
-    def test_indented_code_does_not_hide_following_link(self) -> None:
-        md = b"\n    [Start][]\n\n[after](href)\n"
         refs = collect(md)
         assert len(refs) == 1
 

--- a/python/zensical/collectors/references/cursor.py
+++ b/python/zensical/collectors/references/cursor.py
@@ -169,13 +169,6 @@ def _scan(cursor: Cursor) -> Iterator[Reference]:
     while cursor.pos < cursor.end:
         char = cursor.data[cursor.pos]
 
-        # Top-level indented code block.
-        if cursor.at_line_start():
-            end = _scan_indented_code(cursor)
-            if end is not None:
-                cursor.advance(end - cursor.pos)
-                continue
-
         # Snippet directives and section markers: --8<-- ...
         if cursor.at_line_start():
             end = _scan_snippet(cursor)
@@ -403,37 +396,6 @@ def _scan(cursor: Cursor) -> Iterator[Reference]:
 
         # Literal
         cursor.advance(1)
-
-
-# ---------------------------------------------------------------------------
-
-
-def _scan_indented_code(cursor: Cursor) -> int | None:
-    """Scan for a top-level indented code block."""
-    line = _find_line_start(cursor, cursor.pos)
-    if not _is_previous_line_blank(cursor, line):
-        return None
-
-    pos = line
-    indent, end = _measure_indent(cursor, pos)
-    if indent < 4:  # noqa: PLR2004
-        return None
-    if end >= cursor.end or cursor.data[end] in (_CR, _NL):
-        return None
-
-    # Consume the whole chunk: indented lines plus blank continuation lines.
-    pos = _skip_line(cursor, end)
-    while pos < cursor.end:
-        if _is_blank_line(cursor, pos):
-            pos = _skip_line(cursor, pos)
-            continue
-
-        indent, end = _measure_indent(cursor, pos)
-        if indent < 4:  # noqa: PLR2004
-            break
-        pos = _skip_line(cursor, end)
-
-    return pos
 
 
 # ---------------------------------------------------------------------------
@@ -1645,23 +1607,6 @@ def _skip_whitespace(cursor: Cursor, pos: int) -> int:
     while pos < cursor.end and cursor.data[pos] in _WHITESPACE:
         pos += 1
     return pos
-
-
-def _measure_indent(cursor: Cursor, pos: int) -> tuple[int, int]:
-    """Return visual indentation width and first non-whitespace position."""
-    indent = 0
-    while pos < cursor.end:
-        char = cursor.data[pos]
-        if char == _SPACE:
-            indent += 1
-            pos += 1
-            continue
-        if char == _TAB:
-            indent += 4 - (indent % 4)
-            pos += 1
-            continue
-        break
-    return indent, pos
 
 
 def _skip_whitespace_newline(cursor: Cursor, pos: int) -> int:


### PR DESCRIPTION
This reverts commit c40f649f7bb3be56e15b52b2daa4af2558485777, as it was causing more issues with reference-style links, for example https://github.com/zensical/zensical/issues/735. We are working on a better solution.
