### PR TITLE
chore: release v0.0.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.44"
+version = "0.0.45"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.44"
+version = "0.0.45"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version reverts a behavior change in link validation that was introduced in 0.0.44 which is causing false positives.
