### PR TITLE
fix: don't crash on invalid URLs in Markdown (#755)

### DIFF
--- a/python/zensical/extensions/links.py
+++ b/python/zensical/extensions/links.py
@@ -191,7 +191,10 @@ def _is_relative(value: str) -> bool:
         return False
 
     # Absolute URLs (e.g. `https://example.com`) and protocol-relative URLs
-    url = urlparse(value)
+    try:
+        url = urlparse(value)
+    except ValueError:
+        return False
     if url.scheme or url.netloc or url.path.startswith("/"):
         return False
 


### PR DESCRIPTION
Issue #755