### PR TITLE
chore: release v0.0.47

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.46"
+version = "0.0.47"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-serve"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "base64",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-zensical-serve = { version = "0.0.3", path = "crates/zensical-serve" }
+zensical-serve = { version = "0.0.4", path = "crates/zensical-serve" }
 zensical-watch = { version = "0.0.5", path = "crates/zensical-watch" }
 
 ahash = "0.8"

--- a/crates/zensical-serve/Cargo.toml
+++ b/crates/zensical-serve/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-serve"
-version = "0.0.3"
+version = "0.0.4"
 description = "HTTP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.46"
+version = "0.0.47"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This release adds native support for [markdown-exec](https://github.com/pawamoy/markdown-exec), improves compatibility around generated URLs and project configuration, and updates the user interface to `v0.0.20`.

Zensical now supports [markdown-exec], an MkDocs plugin that executes Python code blocks during the build and injects the result into the rendered page. In practice, this makes it easier to build interactive technical documentation, generated examples, and executable snippets that integrate directly with the theme in both `classic` and `modern` variants.

Additionally, the [user interface](https://github.com/zensical/ui) is updated to [v0.0.20](https://github.com/zensical/ui/releases/tag/v0.0.20), which includes client-side support for `markdown-exec` and several styling and interaction fixes. Mermaid diagram colors are now applied correctly for sequence numbers and activations, flow chart arrows, and state diagram arrows. Search filter scrollbars no longer overlap selectable items, and images using `data-gallery` are attributed correctly again.