### PR TITLE
fix: fix relative/scoped cross-refs support for mkdocstrings-python (#796)

### DIFF
--- a/python/zensical/extensions/autorefs.py
+++ b/python/zensical/extensions/autorefs.py
@@ -150,7 +150,11 @@ class AutorefsHookInterface(ABC):
 class AutorefsInlineProcessor(ReferenceInlineProcessor):
     """A Markdown extension to handle inline references."""
 
-    name = "autorefs"
+    # We have to keep the legacy name `mkdocs-autorefs` because mkdocstrings
+    # checks that the name of the original inline processor is a member of
+    # `self.md.inlinepatterns` to know whether it must assign the hook.
+    # This can be changed to something else if we update mkdocstrings.
+    name = "mkdocs-autorefs"
     hook: AutorefsHookInterface | None = None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
Issue #796.