### PR TITLE
chore: upgrade actions versions in bootstrapped docs workflow, to match docs

### DIFF
--- a/python/zensical/bootstrap/.github/workflows/docs.yml
+++ b/python/zensical/bootstrap/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/configure-pages@v6
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x


### PR DESCRIPTION
Should maybe use `fix` type?