### PR TITLE
chore: release v0.0.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.47"
+version = "0.0.48"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.47"
+version = "0.0.48"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version updates the [user interface](https://github.com/zensical/ui) to [v0.0.21](https://github.com/zensical/ui/releases/tag/v0.0.21), bringing the latest fixes for Pyodide-powered code execution, search, and ANSI color rendering.

It also improves configuration parsing and defaults, and fixes relative and scoped cross-references for `mkdocstrings-python`.