### PR TITLE
fix: cache autorefs data for cross-ref resolution across rebuilds (#805)

### DIFF
--- a/crates/zensical/src/structure/markdown/autorefs.rs
+++ b/crates/zensical/src/structure/markdown/autorefs.rs
@@ -261,6 +261,20 @@ impl Autorefs {
         Self::default()
     }
 
+    /// Merges another `Autorefs` into this one.
+    ///
+    /// Entries from `other` take precedence over existing entries. Used to
+    /// merge stale cached autorefs with fresh data from the Python process,
+    /// so that pages not re-processed in the current build retain their
+    /// previously registered identifiers while newly processed pages override
+    /// any stale entries.
+    pub fn merge(&mut self, other: Autorefs) {
+        self.primary.extend(other.primary);
+        self.secondary.extend(other.secondary);
+        self.inventory.extend(other.inventory);
+        self.titles.extend(other.titles);
+    }
+
     /// Parses HTML attributes string into a HashMap.
     ///
     /// @todo Document that this is not the most resilient HTML parser

--- a/crates/zensical/src/structure/nav.rs
+++ b/crates/zensical/src/structure/nav.rs
@@ -25,7 +25,9 @@
 
 //! Navigation.
 
+use std::fs;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::{Path, PathBuf};
 
 use ahash::HashMap;
 use pyo3::types::PyAnyMethods;
@@ -73,10 +75,16 @@ pub struct Navigation {
 impl Navigation {
     /// Creates a navigation from the given items.
     pub fn new(
-        mut items: Vec<NavigationItem>, pages: Vec<(Key<Id>, Page)>,
+        cache_dir: PathBuf, mut items: Vec<NavigationItem>,
+        pages: Vec<(Key<Id>, Page)>,
     ) -> Self {
+        // Fetch and cache autorefs once, used by both branches below
+        let autorefs = get_autorefs_cached(&cache_dir);
+
         if items.is_empty() {
-            return Self::from(pages);
+            let mut nav = Self::from(pages);
+            nav.autorefs = autorefs;
+            return nav;
         }
 
         // Create a map of pages for easy lookup, so we can resolve titles and
@@ -157,8 +165,6 @@ impl Navigation {
             items.hash(&mut hasher);
             hasher.finish()
         };
-
-        let autorefs = get_autorefs();
 
         // Return navigation
         Self {
@@ -365,6 +371,8 @@ impl From<Vec<(Key<Id>, Page)>> for Navigation {
             hasher.finish()
         };
 
+        // Fetch without caching — Navigation::new() will override this with
+        // the cached+merged result when called through the normal build path.
         let autorefs = get_autorefs();
 
         // Determine homepage and return navigation
@@ -439,6 +447,29 @@ pub(crate) fn to_title(component: &str) -> String {
     } else {
         title
     }
+}
+
+fn get_autorefs_cached(cache_dir: &Path) -> Autorefs {
+    let path = cache_dir.join("autorefs.json");
+
+    // Load previously cached autorefs, falling back to empty if unavailable
+    let mut autorefs = fs::read(&path)
+        .ok()
+        .and_then(|data| serde_json::from_slice::<Autorefs>(&data).ok())
+        .unwrap_or_default();
+
+    // Fetch fresh data from the Python process and merge, giving it precedence
+    // over cached entries — pages re-processed in this build are authoritative
+    // while identifiers from unchanged (cached) pages are preserved from cache
+    autorefs.merge(get_autorefs());
+
+    // Write merged autorefs back to cache
+    if let Ok(data) = serde_json::to_string_pretty(&autorefs) {
+        let _ = fs::create_dir_all(cache_dir);
+        let _ = fs::write(&path, data);
+    }
+
+    autorefs
 }
 
 fn get_autorefs() -> Autorefs {

--- a/crates/zensical/src/workflow.rs
+++ b/crates/zensical/src/workflow.rs
@@ -347,7 +347,7 @@ pub fn generate_nav(
 ) -> Stream<Id, Navigation> {
     let config = config.clone();
     pages.map(move |pages: Vec<(Key<Id>, Page)>| {
-        Navigation::new(config.project.nav.clone(), pages)
+        Navigation::new(config.get_cache_dir(), config.project.nav.clone(), pages)
     })
 }
 


### PR DESCRIPTION
Issue #805.

On a first build without cache, pages are built and cross-references resolved thanks to the autorefs data retrieved from the Python interpreter.

On a second build, if a page changed, the cache is not reused, so the page is rebuilt and cross-references within it must be resolved again, but if the target symbols were rendered in other, already cached pages, the Python interpreter doesn't hold the necessary data to resolve these cross-references.

We fix this by caching autorefs data. We still need to update the data retrieved from the cache with the data retrieved from the Python interpreter, to give precedence to autorefs data for pages that were rebuilt.

This solution still has the issue that stale data is never removed from the cache (for example, symbols that were completely deleted from the sources and API docs). The API would have to change a lot and often for it to have an impact though. Cleaning (`rm .cache/autorefs.json` or `zensical build --clean`) from time to time easily mitigates this.

On a project with a medium to large public API (Griffe), this generates a 60K+ lines JSON file, with a size of 4.4MB. We could drop indentation and newlines. The contents might also be very compressible.

~~I notice that it contains an ID-URL map of all the loaded inventories. We might be able to drop those from the cache if they are always loaded when building, even when no page is rebuilt. 15K lines for inventories loaded in Griffe's docs (Python standard library and typing-extensions), about 25% of the total file size.~~ I checked, if no page is rebuilt, the `render` function is never called, so no Markdown parser is instantiated, meaning the inventories are not downloaded. We must include them in the cached data.