### PR TITLE
chore: release v0.0.51

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.50"
+version = "0.0.51"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.50"
+version = "0.0.51"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version improves cached rebuilds by persisting `objects.inv` and autorefs data, fixes stale builds after removing files, and upgrades `soupsieve` to address vulnerabilities.