### PR TITLE
fix: broken link to extensions doc page (#827)

### DIFF
--- a/python/zensical/bootstrap/zensical.toml
+++ b/python/zensical/bootstrap/zensical.toml
@@ -310,7 +310,7 @@ toggle.name = "Switch to light mode"
 # but you can customize this list to your needs.
 #
 # Read more:
-# - https://zensical.org/docs/setup/extensions/
+# - https://zensical.org/docs/setup/extensions/about
 # ----------------------------------------------------------------------------
 [project.markdown_extensions.abbr]
 [project.markdown_extensions.admonition]


### PR DESCRIPTION
<!--
  Before opening a PR, please read our contributing guide:
  https://zensical.org/docs/community/contribute/pull-requests/
-->

## Summary

Fix broken link in bootstrap `zensical.toml` file to the extensions doc page.

## Related issue

This pull request is linked to the following issue: #827

## Checklist

<!-- All boxes must be checked -->

Please ensure that your PR meets the following requirements:

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]