### PR TITLE
performance: share navigation autorefs via Arc (#838)

### DIFF
--- a/crates/zensical/src/structure/nav.rs
+++ b/crates/zensical/src/structure/nav.rs
@@ -28,10 +28,11 @@
 use std::fs;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use ahash::HashMap;
-use pyo3::types::PyAnyMethods;
-use pyo3::{FromPyObject, Python};
+use pyo3::types::{PyAny, PyAnyMethods};
+use pyo3::{Bound, FromPyObject, PyResult, Python};
 use serde::Serialize;
 use zrx::id::Id;
 use zrx::scheduler::{Key, Value};
@@ -63,7 +64,8 @@ pub struct Navigation {
     /// Homepage, if defined.
     pub homepage: Option<NavigationItem>,
     /// Autorefs (mkdocstrings).
-    pub autorefs: Autorefs,
+    #[pyo3(from_py_with = extract_shared_autorefs)]
+    pub autorefs: Arc<Autorefs>,
     /// Precomputed hash.
     pub hash: u64,
 }
@@ -83,7 +85,7 @@ impl Navigation {
 
         if items.is_empty() {
             let mut nav = Self::from(pages);
-            nav.autorefs = autorefs;
+            nav.autorefs = Arc::new(autorefs);
             return nav;
         }
 
@@ -170,7 +172,7 @@ impl Navigation {
         Self {
             items,
             homepage,
-            autorefs,
+            autorefs: Arc::new(autorefs),
             hash,
         }
     }
@@ -378,7 +380,7 @@ impl From<Vec<(Key<Id>, Page)>> for Navigation {
         // Determine homepage and return navigation
         Self {
             homepage: items.iter().find(|item| item.is_index).cloned(),
-            autorefs,
+            autorefs: Arc::new(autorefs),
             items,
             hash,
         }
@@ -449,6 +451,12 @@ pub(crate) fn to_title(component: &str) -> String {
     }
 }
 
+fn extract_shared_autorefs(
+    value: &Bound<'_, PyAny>,
+) -> PyResult<Arc<Autorefs>> {
+    value.extract::<Autorefs>().map(Arc::new)
+}
+
 fn get_autorefs_cached(cache_dir: &Path) -> Autorefs {
     let path = cache_dir.join("autorefs.json");
 
@@ -491,6 +499,20 @@ fn get_autorefs() -> Autorefs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_clone_shares_autorefs() {
+        let nav = Navigation {
+            items: Vec::new(),
+            homepage: None,
+            autorefs: Arc::new(Autorefs::new()),
+            hash: 0,
+        };
+
+        let clone = nav.clone();
+
+        assert!(Arc::ptr_eq(&nav.autorefs, &clone.autorefs));
+    }
 
     /// https://github.com/zensical/zensical/issues/66
     #[test]


### PR DESCRIPTION
<!--
  Before opening a PR, please read our contributing guide:
  https://zensical.org/docs/community/contribute/pull-requests/
-->

## Summary

`Navigation` owns `Autorefs` by value, so each per-page clone in the render pipeline duplicates the entire autorefs map. On large API-reference builds (AWS SDK for Python: 4,302 pages, 23.5 MB autorefs) this projected to ~101 GB and was killed even with 144 GiB of memory.

This PR wraps `Navigation.autorefs` in `Arc<Autorefs>` so clones share a single allocation instead of deep-copying it. A PyO3 `from_py_with` extractor (`extract_shared_autorefs`) preserves the Python→Rust conversion, and all construction sites (`new`, `From`, `with_active`) are updated. There is no behavior change, only how the map is shared across clones.

On the reproduction build, max RSS dropped from **~2.57 GB → ~0.32 GB** with essentially unchanged build time. Added `test_clone_shares_autorefs` (asserts `Arc::ptr_eq` across a clone); `cargo fmt` and `cargo clippy` are clean.

## Related issue

<!-- Every PR from an outside contributor must be linked to an issue -->

This pull request is linked to the following issue: https://github.com/zensical/zensical/issues/838

## Checklist

<!-- All boxes must be checked -->

Please ensure that your PR meets the following requirements:

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] I have created an issue to discuss the change and received agreement from maintainers to proceed
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
