### PR TITLE
feature: support `strict` configuration option (#840)

### DIFF
--- a/crates/zensical/src/config/project.rs
+++ b/crates/zensical/src/config/project.rs
@@ -62,6 +62,8 @@ pub struct Project {
     pub site_dir: String,
     /// Whether to use directory URLs.
     pub use_directory_urls: bool,
+    /// Whether to abort the build on any warnings.
+    pub strict: bool,
     /// Development server address.
     pub dev_addr: String,
     /// Copyright notice.

--- a/crates/zensical/src/lib.rs
+++ b/crates/zensical/src/lib.rs
@@ -185,7 +185,9 @@ fn run(config_file: &PathBuf, mode: Mode) -> PyResult<bool> {
 
     // Determine if strict mode is enabled
     let strict = match &mode {
-        Mode::Build(options) => options.strict.unwrap_or(false),
+        Mode::Build(options) => {
+            options.strict.unwrap_or(false) || config.project.strict
+        }
         Mode::Serve(_, _) => false,
     };
 

--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -411,6 +411,7 @@ def _apply_defaults(config: dict, path: str) -> dict:
     set_default(config, "site_description", None, str)
     set_default(config, "site_author", None, str)
     set_default(config, "use_directory_urls", True, bool)
+    set_default(config, "strict", False, bool)
     set_default(config, "dev_addr", "localhost:8000", str)
     set_default(config, "copyright", None, str)
     set_default(config, "watch", [], list)


### PR DESCRIPTION
Issue #840.

If we actually set the `Config.project.strict` value using the command line flag, we could also clean up some code, like the `validate()` function which takes both `config` and `strict` parameters. But applying flags to the loaded config doesn't look very elegant to me. We can probably keep this change minimal.