### PR TITLE
chore: release v0.0.53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.52"
+version = "0.0.53"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds support for enabling strict mode directly in `mkdocs.yml` or `zensical.toml`, allowing warnings to fail builds consistently without the `--strict` command-line option. It also reduces memory usage by sharing cross-reference data between navigation clones.

Additionally, the user interface is updated to `v0.0.24`, improving search rendering for right-to-left languages and adding four new Lucide icons. The generated `zensical.toml` now uses TOML 1.1 syntax, and `pymdownx` is updated to version 11.0 to address a vulnerability.