### PR TITLE
performance: reduce peak memory usage by 8-10x 

### DIFF
--- a/crates/zensical/src/structure/nav.rs
+++ b/crates/zensical/src/structure/nav.rs
@@ -60,7 +60,8 @@ use iter::Iter;
 #[derive(Clone, Debug, PartialEq, Eq, FromPyObject, Serialize)]
 pub struct Navigation {
     /// Navigation items.
-    pub items: Vec<NavigationItem>,
+    #[pyo3(from_py_with = extract_shared_items)]
+    pub items: Arc<Vec<NavigationItem>>,
     /// Homepage, if defined.
     pub homepage: Option<NavigationItem>,
     /// Autorefs (mkdocstrings).
@@ -170,7 +171,7 @@ impl Navigation {
 
         // Return navigation
         Self {
-            items,
+            items: Arc::new(items),
             homepage,
             autorefs: Arc::new(autorefs),
             hash,
@@ -204,7 +205,8 @@ impl Navigation {
 
         // Set active state starting from the root
         let mut items = self.items;
-        recurse(&mut items, &page.url);
+        let items_mut = Arc::<Vec<NavigationItem>>::make_mut(&mut items);
+        recurse(items_mut, &page.url);
         Self {
             items,
             homepage: self.homepage,
@@ -356,9 +358,9 @@ impl From<Vec<(Key<Id>, Page)>> for Navigation {
 
             // Insert page into the section
             section.push(NavigationItem {
-                title: Some(page.title),
-                url: Some(page.url),
-                canonical_url: page.canonical_url,
+                title: Some(page.title.clone()),
+                url: Some(page.url.clone()),
+                canonical_url: page.canonical_url.clone(),
                 meta: Some(page.meta.clone()),
                 children: Vec::new(),
                 is_index: is_index(&file),
@@ -381,7 +383,7 @@ impl From<Vec<(Key<Id>, Page)>> for Navigation {
         Self {
             homepage: items.iter().find(|item| item.is_index).cloned(),
             autorefs: Arc::new(autorefs),
-            items,
+            items: Arc::new(items),
             hash,
         }
     }
@@ -457,6 +459,12 @@ fn extract_shared_autorefs(
     value.extract::<Autorefs>().map(Arc::new)
 }
 
+fn extract_shared_items(
+    value: &Bound<'_, PyAny>,
+) -> PyResult<Arc<Vec<NavigationItem>>> {
+    value.extract::<Vec<NavigationItem>>().map(Arc::new)
+}
+
 fn get_autorefs_cached(cache_dir: &Path) -> Autorefs {
     let path = cache_dir.join("autorefs.json");
 
@@ -501,9 +509,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_clone_shares_autorefs() {
+    fn test_clone_shares_immutable_data() {
         let nav = Navigation {
-            items: Vec::new(),
+            items: Arc::new(Vec::new()),
             homepage: None,
             autorefs: Arc::new(Autorefs::new()),
             hash: 0,
@@ -512,6 +520,7 @@ mod tests {
         let clone = nav.clone();
 
         assert!(Arc::ptr_eq(&nav.autorefs, &clone.autorefs));
+        assert!(Arc::ptr_eq(&nav.items, &clone.items));
     }
 
     /// https://github.com/zensical/zensical/issues/66

--- a/crates/zensical/src/structure/page.rs
+++ b/crates/zensical/src/structure/page.rs
@@ -26,10 +26,11 @@
 //! Page.
 
 use minijinja::{context, Error};
-use pyo3::FromPyObject;
 use serde::Serialize;
 use std::collections::BTreeMap;
+use std::ops::Deref;
 use std::path::PathBuf;
+use std::sync::Arc;
 use zensical_serve::http::Uri;
 use zrx::id::Id;
 use zrx::scheduler::Value;
@@ -48,16 +49,13 @@ use super::toc::Section;
 // Structs
 // ----------------------------------------------------------------------------
 
-/// Page.
+/// Immutable page data shared between scheduler branches.
 ///
-/// This data type contains all data necessary for rendering a page, including
-/// its content, metadata, table of contents, and relations to other pages. In
-/// the future, we're going to split this up into smaller components, to make
-/// rendering more modular, but right now, we just replicate what MkDocs does.
-#[allow(clippy::struct_field_names)]
-#[derive(Clone, Debug, PartialEq, Eq, FromPyObject, Serialize)]
-#[pyo3(from_item_all)]
-pub struct Page {
+/// Page values are cloned by the scheduler as they fan out into navigation,
+/// search, validation, and rendering branches. Keeping the immutable payload
+/// behind an [`Arc`] makes those clones constant-sized.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct PageData {
     /// Page target URL.
     pub url: String,
     /// Page canonical URL.
@@ -76,6 +74,20 @@ pub struct Page {
     pub toc: Vec<Section>,
     /// Search index.
     pub search: Vec<SearchItem>,
+}
+
+/// Page.
+///
+/// This data type contains all data necessary for rendering a page, including
+/// its content, metadata, table of contents, and relations to other pages. The
+/// immutable render inputs are shared across scheduler branches, while page
+/// relations remain local because they are populated during rendering.
+#[allow(clippy::struct_field_names)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct Page {
+    /// Immutable page data.
+    #[serde(flatten)]
+    data: Arc<PageData>,
     /// Ancestor pages.
     pub ancestors: Vec<NavigationItem>,
     /// Previous page.
@@ -175,15 +187,17 @@ impl Page {
         // single struct, but to split up the page as necessary later on.
         let path = root_dir.join(id.to_path());
         Page {
-            url,
-            title: markdown.title,
-            meta: markdown.meta,
-            canonical_url,
-            edit_url,
-            content: markdown.content,
-            toc: markdown.toc,
-            search: markdown.search,
-            path: path.to_string_lossy().into_owned(),
+            data: Arc::new(PageData {
+                url,
+                title: markdown.title,
+                meta: markdown.meta,
+                canonical_url,
+                edit_url,
+                content: markdown.content,
+                toc: markdown.toc,
+                search: markdown.search,
+                path: path.to_string_lossy().into_owned(),
+            }),
             ancestors: Vec::new(),
             previous_page: None,
             next_page: None,
@@ -247,8 +261,65 @@ impl Page {
 impl Value for Page {}
 
 // ----------------------------------------------------------------------------
+
+impl Deref for Page {
+    type Target = PageData;
+
+    /// Dereferences to immutable page data.
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+// ----------------------------------------------------------------------------
 // Type alises
 // ----------------------------------------------------------------------------
 
 /// Page metadata.
 pub type PageMeta = BTreeMap<String, Dynamic>;
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn page() -> Page {
+        Page {
+            data: Arc::new(PageData {
+                url: String::from("/"),
+                canonical_url: None,
+                edit_url: None,
+                title: String::from("Home"),
+                meta: PageMeta::new(),
+                path: String::from("site/index.html"),
+                content: String::from("<h1>Home</h1>"),
+                toc: Vec::new(),
+                search: Vec::new(),
+            }),
+            ancestors: Vec::new(),
+            previous_page: None,
+            next_page: None,
+        }
+    }
+
+    #[test]
+    fn clone_shares_immutable_data() {
+        let page = page();
+        let clone = page.clone();
+
+        assert!(Arc::ptr_eq(&page.data, &clone.data));
+    }
+
+    #[test]
+    fn serialization_keeps_flat_page_shape() {
+        let value = serde_json::to_value(page()).unwrap();
+
+        assert_eq!(value["url"], "/");
+        assert_eq!(value["title"], "Home");
+        assert!(value.get("data").is_none());
+    }
+}

--- a/crates/zensical/src/structure/search.rs
+++ b/crates/zensical/src/structure/search.rs
@@ -116,7 +116,7 @@ impl SearchIndex {
 
             // For each page, adjust the location of each item and add it to
             // the overall list
-            for mut item in page.search {
+            for mut item in page.search.iter().cloned() {
                 let location = match item.location {
                     Some(id) => format!("{}#{}", page.url, id),
                     _ => page.url.clone(),

--- a/scripts/memory_fixture.py
+++ b/scripts/memory_fixture.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2025-2026 Zensical and contributors
+
+# SPDX-License-Identifier: MIT
+# All contributions are certified under the DCO
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""Generate a deterministic Zensical project for memory measurements."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "directory",
+        type=Path,
+        help="new directory in which to create the fixture",
+    )
+    parser.add_argument(
+        "--pages",
+        type=int,
+        default=400,
+        help="number of Markdown pages to generate (default: 400)",
+    )
+    parser.add_argument(
+        "--sections",
+        type=int,
+        default=12,
+        help="second-level headings per page (default: 12)",
+    )
+    parser.add_argument(
+        "--groups",
+        type=int,
+        default=20,
+        help="directories across which pages are spread (default: 20)",
+    )
+    return parser.parse_args()
+
+
+def page_contents(page: int, sections: int) -> str:
+    """Create deterministic Markdown with metadata and search entries."""
+    lines = [
+        "---",
+        f"title: Memory fixture page {page:04d}",
+        "tags:",
+        f"  - group-{page % 7}",
+        f"  - topic-{page % 13}",
+        "metadata:",
+        f"  owner: team-{page % 5}",
+        "  lifecycle: maintained",
+        "---",
+        "",
+        f"# Memory fixture page {page:04d}",
+        "",
+    ]
+    for section in range(sections):
+        lines.extend(
+            [
+                f"## Section {section:02d}",
+                "",
+                (
+                    f"Page {page:04d}, section {section:02d} contains "
+                    "deterministic prose used to exercise Markdown parsing, "
+                    "template rendering, navigation cloning, and search "
+                    "index construction under a representative documentation "
+                    "build."
+                ),
+                "",
+                (
+                    "The second paragraph deliberately contains "
+                    "**formatting**, `inline code`, and enough text to make "
+                    "retained content visible in process-level memory "
+                    "measurements."
+                ),
+                "",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def create_fixture(
+    directory: Path, *, pages: int, sections: int, groups: int
+) -> None:
+    """Create the benchmark project, refusing to overwrite existing data."""
+    if pages < 1:
+        raise ValueError("--pages must be at least 1")
+    if sections < 1:
+        raise ValueError("--sections must be at least 1")
+    if groups < 1:
+        raise ValueError("--groups must be at least 1")
+    if directory.exists():
+        message = f"refusing to overwrite existing path: {directory}"
+        raise FileExistsError(message)
+
+    docs = directory / "docs"
+    docs.mkdir(parents=True)
+    (directory / "zensical.toml").write_text(
+        """[project]
+site_name = "Memory fixture"
+site_url = "https://example.com/"
+
+[project.theme]
+language = "en"
+""",
+        encoding="utf-8",
+    )
+
+    for page in range(pages):
+        group = docs / f"group-{page % groups:02d}"
+        group.mkdir(exist_ok=True)
+        path = group / f"page-{page:04d}.md"
+        path.write_text(page_contents(page, sections), encoding="utf-8")
+
+
+def main() -> int:
+    """Generate a fixture from command-line arguments."""
+    args = parse_args()
+    create_fixture(
+        args.directory.resolve(),
+        pages=args.pages,
+        sections=args.sections,
+        groups=args.groups,
+    )
+    print(
+        f"Created {args.pages} pages with {args.sections} sections each in "
+        f"{args.directory.resolve()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/memory_profile.py
+++ b/scripts/memory_profile.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2025-2026 Zensical and contributors
+
+# SPDX-License-Identifier: MIT
+# All contributions are certified under the DCO
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+"""Measure peak memory for a command using the Linux proc filesystem."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+@dataclass
+class Memory:
+    """Memory counters reported by Linux, in KiB."""
+
+    rss_kib: int = 0
+    hwm_kib: int = 0
+    anonymous_kib: int = 0
+    file_kib: int = 0
+    swap_kib: int = 0
+    pss_kib: int = 0
+    private_kib: int = 0
+
+    def include(self, sample: Memory) -> None:
+        """Update every counter to its observed maximum."""
+        for name in self.__dataclass_fields__:
+            setattr(self, name, max(getattr(self, name), getattr(sample, name)))
+
+
+@dataclass
+class Run:
+    """One measured command invocation."""
+
+    elapsed_seconds: float
+    exit_code: int
+    samples: int
+    peak: Memory
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        help="working directory for the measured command",
+    )
+    parser.add_argument(
+        "--interval-ms",
+        type=float,
+        default=5.0,
+        help="sampling interval in milliseconds (default: 5)",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help="number of command invocations (default: 1)",
+    )
+    parser.add_argument(
+        "--json",
+        type=Path,
+        help="also write the complete result as JSON",
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="command to measure, conventionally preceded by --",
+    )
+    return parser.parse_args()
+
+
+def read_key_values(path: Path) -> dict[str, int]:
+    """Read KiB counters from a proc status-like file."""
+    values: dict[str, int] = {}
+    try:
+        contents = path.read_text(encoding="ascii")
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        return values
+
+    for line in contents.splitlines():
+        name, separator, value = line.partition(":")
+        if not separator:
+            continue
+        fields = value.split()
+        if fields and fields[0].isdigit():
+            values[name] = int(fields[0])
+    return values
+
+
+def sample_process(pid: int) -> Memory:
+    """Read current and high-water memory counters for one process."""
+    status = read_key_values(Path("/proc") / str(pid) / "status")
+    rollup = read_key_values(Path("/proc") / str(pid) / "smaps_rollup")
+    return Memory(
+        rss_kib=status.get("VmRSS", 0),
+        hwm_kib=status.get("VmHWM", 0),
+        anonymous_kib=status.get("RssAnon", 0),
+        file_kib=status.get("RssFile", 0),
+        swap_kib=status.get("VmSwap", 0),
+        pss_kib=rollup.get("Pss", 0),
+        private_kib=(
+            rollup.get("Private_Clean", 0) + rollup.get("Private_Dirty", 0)
+        ),
+    )
+
+
+def measure(
+    command: Sequence[str], *, cwd: Path | None, interval: float
+) -> Run:
+    """Run a command and sample its process memory until completion."""
+    started = time.monotonic()
+    process = subprocess.Popen(command, cwd=cwd)
+    peak = Memory()
+    samples = 0
+
+    while process.poll() is None:
+        peak.include(sample_process(process.pid))
+        samples += 1
+        time.sleep(interval)
+
+    # VmHWM survives short spikes between samples and is retained until exit.
+    # This last read can still succeed briefly while the process is a zombie.
+    peak.include(sample_process(process.pid))
+    elapsed = time.monotonic() - started
+    return Run(elapsed, process.returncode, samples, peak)
+
+
+def mebibytes(kibibytes: float) -> str:
+    """Format a KiB measurement as MiB."""
+    return f"{kibibytes / 1024:.2f} MiB"
+
+
+def print_run(index: int, run: Run) -> None:
+    """Print one compact human-readable result."""
+    print(
+        f"run {index}: peak RSS {mebibytes(run.peak.hwm_kib)}, "
+        f"peak PSS {mebibytes(run.peak.pss_kib)}, "
+        f"peak private {mebibytes(run.peak.private_kib)}, "
+        f"elapsed {run.elapsed_seconds:.3f}s, exit {run.exit_code}"
+    )
+
+
+def main() -> int:
+    """Measure the requested command."""
+    args = parse_args()
+    command = args.command
+    if command[:1] == ["--"]:
+        command = command[1:]
+    if not command:
+        raise SystemExit("a command is required after --")
+    if args.repeat < 1:
+        raise SystemExit("--repeat must be at least 1")
+    if args.interval_ms <= 0:
+        raise SystemExit("--interval-ms must be greater than zero")
+    if not Path("/proc/self/status").exists():
+        raise SystemExit("memory_profile.py currently requires Linux /proc")
+
+    runs: list[Run] = []
+    for index in range(1, args.repeat + 1):
+        run = measure(
+            command,
+            cwd=args.cwd,
+            interval=args.interval_ms / 1000,
+        )
+        runs.append(run)
+        print_run(index, run)
+        if run.exit_code != 0:
+            break
+
+    summary = {
+        "command": command,
+        "cwd": str(args.cwd.resolve()) if args.cwd else None,
+        "runs": [asdict(run) for run in runs],
+        "median": {
+            "peak_rss_kib": statistics.median(run.peak.hwm_kib for run in runs),
+            "peak_pss_kib": statistics.median(run.peak.pss_kib for run in runs),
+            "peak_private_kib": statistics.median(
+                run.peak.private_kib for run in runs
+            ),
+            "elapsed_seconds": statistics.median(
+                run.elapsed_seconds for run in runs
+            ),
+        },
+    }
+    if len(runs) > 1:
+        print(
+            f"median: peak RSS {mebibytes(summary['median']['peak_rss_kib'])}, "
+            f"peak PSS {mebibytes(summary['median']['peak_pss_kib'])}, "
+            "peak private "
+            f"{mebibytes(summary['median']['peak_private_kib'])}, "
+            f"elapsed {summary['median']['elapsed_seconds']:.3f}s"
+        )
+    if args.json:
+        args.json.write_text(
+            json.dumps(summary, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    return max(run.exit_code for run in runs)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implemented and measured two concrete memory optimizations.

**400-page clean build, 3-run median** |       Before |        After   | Reduction
--- | --- | --- | ---
   Peak RSS            |                  830.69 MiB  |  101.07 MiB    |   87.83%
   Peak PSS                |              821.19 MiB  |   91.46 MiB   |    88.86%
   Peak private memory         |          816.38 MiB  |   86.57 MiB    |   89.40%
   Observed runtime               |           11.41s    |     7.07s   |    38.06%

Changes:

- `crates/zensical/src/structure/nav.rs:61`: navigation trees now use shared ownership. Scheduler fan-out clones a pointer instead of recursively copying the full tree; rendering uses copy-on-write when marking active entries.
- `crates/zensical/src/structure/page.rs:52`: immutable page content, metadata, TOC, and search data are shared between scheduler branches. Render-specific relationships remain local.
- `crates/zensical/src/structure/search.rs:119`: search construction clones only the entries it consumes.

Added reusable tools:

- `scripts/memory_fixture.py:34` generates deterministic documentation workloads.
- `scripts/memory_profile.py:72` samples Linux RSS, PSS, private, anonymous, file, and swap memory, with repeated runs and JSON output.

Example:

```bash
scripts/memory_fixture.py /tmp/zensical-memory --pages 400 --sections 12
```
```bash
scripts/memory_profile.py \
    --cwd /tmp/zensical-memory \
    --repeat 3 \
    --json /tmp/memory.json \
    -- .venv/bin/zensical build --config-file zensical.toml --clean
```