### PR TITLE
chore: release v0.0.55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.54"
+version = "0.0.55"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version fixes two false positives in the reference extractor and reverts Zensical's bootstrapped `zensical.toml` to TOML 1.0, since most editor tooling does not yet support TOML 1.1. Zensical understands both, TOML 1.0 and TOML 1.1, so this change does not affect the functionality of Zensical itself.