### PR TITLE
chore: release v0.0.56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.55"
+version = "0.0.56"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version fixes a regression introduced in 0.0.55, making Zensical report false positives for the deprecated `unresolved_references` setting. Additionally, checking of autorefs is moved to the `invalid_links` setting. Please disable `unresolved_references` - it is not supported anymore, and will be replaced by the reference parser that we're currently testing in [Zensical Studio](https://zensical.org/studio/).