### PR TITLE
chore: release v0.0.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-serve"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "base64",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-zensical-serve = { version = "0.0.4", path = "crates/zensical-serve" }
+zensical-serve = { version = "0.0.5", path = "crates/zensical-serve" }
 zensical-watch = { version = "0.0.5", path = "crates/zensical-watch" }
 
 ahash = "0.8"

--- a/crates/zensical-serve/Cargo.toml
+++ b/crates/zensical-serve/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-serve"
-version = "0.0.4"
+version = "0.0.5"
 description = "HTTP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.56"
+version = "0.0.57"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version improves compatibility with `markdown-exec` by supporting `pymdownx` blocks, raises the maximum HTTP header value size to 8 KiB for proxy-generated cookies, and updates the UI dependency stack and bundled icons. UI performance and palette tooltip behavior were also improved, especially on large pages and in Safari.