### PR TITLE
refactor!: remove x86 and armv7 musl builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,15 +45,17 @@ permissions:
 
 jobs:
   linux:
-    name: Wheel (Linux, ${{ matrix.platform.target }})
+    name: Wheel (Linux, ${{ matrix.platform.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         platform:
-          - target: x86_64
-          - target: x86
-          - target: aarch64
-          - target: armv7
+          - name: x64
+            target: x86_64-unknown-linux-gnu
+          - name: arm64
+            target: aarch64-unknown-linux-gnu
+          - name: armv7
+            target: armv7-unknown-linux-gnueabihf
 
     steps:
       - name: Checkout repository
@@ -92,19 +94,19 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheel-linux-${{ matrix.platform.target }}
+          name: wheel-linux-${{ matrix.platform.name }}
           path: artifacts/*
 
   musllinux:
-    name: Wheel (Linux, musl, ${{ matrix.platform.target }})
+    name: Wheel (Linux, musl, ${{ matrix.platform.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         platform:
-          - target: x86_64
-          - target: x86
-          - target: aarch64
-          - target: armv7
+          - name: x64
+            target: x86_64-unknown-linux-musl
+          - name: arm64
+            target: aarch64-unknown-linux-musl
 
     steps:
       - name: Checkout repository
@@ -139,17 +141,21 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheel-musllinux-${{ matrix.platform.target }}
+          name: wheel-musllinux-${{ matrix.platform.name }}
           path: artifacts/*
 
   windows:
-    name: Wheel (Windows, ${{ matrix.platform.target }})
-    runs-on: windows-latest
+    name: Wheel (Windows, ${{ matrix.platform.name }})
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
         platform:
-          - target: x64
-          - target: x86
+          - name: x64
+            os: windows-2022
+            target: x86_64-pc-windows-msvc
+          - name: arm64
+            os: windows-11-arm
+            target: aarch64-pc-windows-msvc
 
     steps:
       - name: Checkout repository
@@ -161,7 +167,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.x
-          architecture: ${{ matrix.platform.target }}
+          architecture: ${{ matrix.platform.name }}
 
       - name: Prepare build
         run: python scripts/prepare.py
@@ -184,19 +190,21 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheel-windows-${{ matrix.platform.target }}
+          name: wheel-windows-${{ matrix.platform.name }}
           path: artifacts/*
 
   macos:
-    name: Wheel (macOS, ${{ matrix.platform.target }})
-    runs-on: ${{ matrix.platform.runner }}
+    name: Wheel (macOS, ${{ matrix.platform.name }})
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
         platform:
-          - runner: macos-15-intel
-            target: x86_64
-          - runner: macos-15
-            target: aarch64
+          - name: x64
+            os: macos-15-intel
+            target: x86_64-apple-darwin
+          - name: arm64
+            os: macos-15
+            target: aarch64-apple-darwin
 
     steps:
       - name: Checkout repository
@@ -230,7 +238,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheel-macos-${{ matrix.platform.target }}
+          name: wheel-macos-${{ matrix.platform.name }}
           path: artifacts/*
 
   sdist:


### PR DESCRIPTION
## Summary

This reduces the native wheel matrix from 12 to 9 builds:

- Remove Linux x86 wheels for glibc and musl.
- Remove Linux armv7 musl wheels.
- Remove Windows x86 wheels.
- Add Windows arm64 wheels.
- Retain Linux armv7 glibc support.
- Use consistent `x64` and `arm64` labels while keeping the precise Rust target triples.

## Evidence

We queried 90 days of PyPI download data from `bigquery-public-data.pypi.file_downloads`, excluding downloads identified as CI and mapping installer environments to compatible native wheel platforms.

| Platform | Architecture | Downloads | Share | Decision |
| --- | --- | ---: | ---: | --- |
| Linux, glibc | x64 | 454,387 | 88.4052% | Keep |
| macOS | arm64 | 19,709 | 3.8346% | Keep |
| Linux, glibc | arm64 | 18,706 | 3.6394% | Keep |
| Windows | x64 | 11,697 | 2.2758% | Keep |
| Linux, musl | x64 | 7,920 | 1.5409% | Keep |
| Linux, musl | arm64 | 888 | 0.1728% | Keep |
| macOS | x64 | 633 | 0.1232% | Keep |
| Linux, glibc | armv7 | 24 | 0.0047% | Keep provisionally |
| Windows | x86 | 8 | 0.0016% | Remove |
| Linux, glibc | x86 | 7 | 0.0014% | Remove |
| Linux, musl | x86 | 3 | 0.0006% | Remove |
| Linux, musl | armv7 | 0 | 0.0000% | Remove |

The removed targets account for 18 of 513,982 observed compatible downloads, or approximately 0.0035%.

Windows arm64 could not appear in the compatible-wheel table because no Windows arm64 wheel was available. The source-distribution data nevertheless contained 35 Windows arm64 downloads not identified as CI, plus 17 downloads explicitly identified as CI. This suggests missing wheel coverage rather than an absence of demand.

## Resulting support matrix

| Platform | x64 | arm64 | armv7 | x86 |
| --- | :---: | :---: | :---: | :---: |
| Linux, glibc | ✅ | ✅ | ✅ | ❌ |
| Linux, musl | ✅ | ✅ | ❌ | ❌ |
| Windows | ✅ | ✅ | — | ❌ |
| macOS | ✅ | ✅ | — | — |

This retains native wheels for 99.9965% of the observed downloads covered by the previous matrix while adding Windows arm64 support.

Linux glibc armv7 remains supported despite its low volume because it has measurable wheel usage and additional source-distribution activity. Linux musl armv7 had no observed compatible wheel downloads and is therefore removed.

## Naming and build configuration

The workflow now separates the user-facing architecture name from the Rust target:

- `x64` maps to targets such as `x86_64-pc-windows-msvc`.
- `arm64` maps to targets such as `aarch64-pc-windows-msvc`.

`arm64` is used in job and artifact names because it is the clearer platform-facing term. Rust continues to use `aarch64` in target triples.

Windows selects an architecture-specific runner because arm64 builds require `windows-11-arm`. Linux continues to build through the existing manylinux and musllinux tooling.

These naming changes affect CI job and uploaded artifact names. The standards-compliant wheel filenames and platform tags produced by Maturin remain unchanged.

## Validation

- The workflow YAML parses successfully.
- `git diff --check` passes.
- No runtime or package API behavior is changed.

## Data limitations

PyPI downloads are a proxy for installations, not a count of unique users or successful runtime executions. The results are strong enough to identify effectively unused targets, but very small architectures should continue to be reviewed as the user base evolves.
