### PR TITLE
chore: release v0.0.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.57"
+version = "0.0.58"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-serve"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "base64",
  "crossbeam",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-watch"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "ahash",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-zensical-serve = { version = "0.0.5", path = "crates/zensical-serve" }
-zensical-watch = { version = "0.0.5", path = "crates/zensical-watch" }
+zensical-serve = { version = "0.0.6", path = "crates/zensical-serve" }
+zensical-watch = { version = "0.0.6", path = "crates/zensical-watch" }
 
 ahash = "0.8"
 anyhow = "1.0.102"

--- a/crates/zensical-serve/Cargo.toml
+++ b/crates/zensical-serve/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-serve"
-version = "0.0.5"
+version = "0.0.6"
 description = "HTTP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical-watch/Cargo.toml
+++ b/crates/zensical-watch/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-watch"
-version = "0.0.5"
+version = "0.0.6"
 description = "Resilient file watcher"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.57"
+version = "0.0.58"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version marks a major evolution of Zensical's build architecture and completes the most essential MkDocs plugin replacements.

Six new plugin replacements are now included:

- `meta`
- `redirects`
- `minify`
- `tags`
- `literate-nav`
- `awesome-nav`

The existing `search`, `mkdocstrings`, and `autorefs` replacements have also been migrated to the new architecture. We kept their behavior close to the upstream plugins while moving almost all processing into Rust. Python is now primarily responsible for configuration normalization and the narrow Python-Markdown adapter used by `literate-nav`.

Under the hood, the build pipeline now runs on a substantially more efficient ZRX scheduler and stream architecture. Together with more compact intermediate data, shared page state, and fewer allocations, this __reduces peak memory usage by roughly 30–40%__ on large projects. Builds are also modestly faster.

Most remaining build time is now spent rendering Markdown through Python-Markdown. One of our next major performance steps is replacing that stage with our Rust-based, Python-Markdown-compatible parser, as announced in the [June edition](https://mail.zensical.org/monthly/2026/06/) of Zensical Monthly.

Over the coming weeks, we'll focus on adding more plugin replacements so that increasingly complex existing projects can switch to Zensical without missing out on functionality. We'll also continue evolving the module API and make it available to interested early users before releasing it publicly.