### PR TITLE
fix: custom_dir path interpreted incorrectly on Windows (#902)

### DIFF
--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -23,6 +23,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -517,3 +518,20 @@ class TestGetThemeDir:
     def test_get_theme_dir_unknown_raises(self) -> None:
         with pytest.raises(ConfigurationError):
             get_theme_dir("definitely-not-a-real-theme-xyzzy")
+
+    @pytest.mark.skipif(
+        os.name != "nt",
+        reason="Windows-specific path normalization",
+    )
+    def test_custom_theme_dir_normalizes_posix_separators(
+        self, tmp_path: Path
+    ) -> None:
+        custom_dir = tmp_path / "a" / "overrides"
+        custom_dir.mkdir(parents=True)
+
+        theme_dir = cfg_module.get_custom_theme_dir(
+            "a/overrides", str(tmp_path / "mkdocs.yml")
+        )
+
+        assert theme_dir.endswith(r"a\overrides")
+        assert theme_dir == str(custom_dir)

--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -304,7 +304,9 @@ def get_theme_dir(name: str) -> str:
 
 def get_custom_theme_dir(path: str, config_path: str) -> str:
     """Return the custom theme directory."""
-    theme_dir = os.path.join(os.path.dirname(config_path), path)
+    theme_dir = os.path.normpath(
+        os.path.join(os.path.dirname(config_path), path)
+    )
 
     # Validate that custom theme directory exists
     if not os.path.isdir(theme_dir):


### PR DESCRIPTION
## Summary

Fix a regression of file path handling on Windows

## Related issue

This pull request is linked to the following issue: #902

## Checklist

Please ensure that your PR meets the following requirements:

- [x] I have read the [pull request guide] and confirm it meets all outlined requirements
- [x] the PR is in response to an issue opened by another use
- [x] I have [cryptographically signed] all commits and included a `Signed-off-by` trailer, accepting the [DCO]
- [x] I have written or reviewed every line of code myself and can fully explain it – see our policy on [use of Generative AI]

[pull request guide]: https://zensical.org/docs/community/contribute/pull-requests/
[cryptographically signed]: https://zensical.org/docs/community/contribute/pull-requests/#verified-commits
[DCO]: https://zensical.org/docs/community/contribute/pull-requests/#developer-certificate-of-origin
[use of Generative AI]: https://zensical.org/docs/community/contribute/pull-requests/#use-of-generative-ai
