### PR TITLE
chore: release v0.0.59

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.58"
+version = "0.0.59"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.58"
+version = "0.0.59"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version fixes navigation title precedence, Windows `custom_dir` paths, `material/meta` activation, and inline SVG icons processed by the `minify` plugin.