### PR TITLE
chore: release v0.0.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.59"
+version = "0.0.60"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.59"
+version = "0.0.60"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version updates the user interface to 0.0.28, fixing navigation pruning and alternate-link handling while adding 51 new icons. It also adds direct support for the `table-reader` plugin and fixes template inclusion with macros on Windows extended-length paths.