### PR TITLE
fix: relax search validation (#926)

### DIFF
--- a/python/tests/integration/test_search.py
+++ b/python/tests/integration/test_search.py
@@ -33,6 +33,8 @@ import zensical
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 
 _BUILD_OPTIONS: dict[str, Any] = {"clean": False, "strict": False}
 
@@ -147,6 +149,27 @@ def test_search_artifacts_match_mkdocs_contract(tmp_path: Path) -> None:
     assert (tmp_path / "site" / "search.js").read_text() == (
         f"var __index = {compact};"
     )
+
+
+def test_unsupported_material_options_are_silently_ignored(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Known Material options are ignored to keep migration frictionless."""
+    config = _write_project(
+        tmp_path,
+        plugins=(
+            "  - material/search:\n"
+            "      lang:\n"
+            "        - de\n"
+            "      pipeline:\n"
+            "        - stemmer"
+        ),
+    )
+
+    zensical.build(str(config), _BUILD_OPTIONS)
+
+    assert _read_index(tmp_path)["config"]["lang"] == ["en"]
+    assert capsys.readouterr().err == ""
 
 
 def test_search_exclusion_and_disabled_output(tmp_path: Path) -> None:

--- a/python/tests/unit/test_plugin_config.py
+++ b/python/tests/unit/test_plugin_config.py
@@ -146,6 +146,35 @@ def test_rejects_unknown_python_plugin_options(name: str) -> None:
         _convert_plugins({name: {"unknown": True}})
 
 
+@pytest.mark.parametrize("plugin", ["search", "material/search"])
+def test_silently_discards_unsupported_search_options(
+    plugin: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    unsupported = {
+        "fields": {"title": {"boost": 2}},
+        "indexing": "titles",
+        "jieba_dict": "dict.txt",
+        "jieba_dict_user": "user-dict.txt",
+        "lang": ["en", "de"],
+        "min_search_length": 2,
+        "pipeline": ["stemmer"],
+        "prebuild_index": True,
+    }
+    configured = {
+        "enabled": False,
+        "separator": "[\\s-]+",
+        **unsupported,
+    }
+
+    plugins = _convert_plugins({plugin: configured})
+
+    assert plugins["search"]["config"] == {
+        "enabled": False,
+        "separator": "[\\s-]+",
+    }
+    assert capsys.readouterr().err == ""
+
+
 @pytest.mark.parametrize("name", SHIM_PLUGINS)
 def test_normalizes_null_shim_configuration(name: str) -> None:
     plugins = _convert_plugins({name: None})

--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -67,7 +67,6 @@ representation in Rust. Thus, we just keep the configuration on the Python
 side, and use it directly when needed. It's a hack but will do for now.
 """
 
-
 # ----------------------------------------------------------------------------
 # Constants
 # ----------------------------------------------------------------------------
@@ -1448,7 +1447,22 @@ def _convert_plugins(value: Any, config: dict) -> dict:
 
     # Search is enabled by default, even when it isn't explicitly configured.
     search = plugins.pop("search", {})
-    _reject_unknown_options("search", search, {"enabled", "separator"})
+    supported = {"enabled", "separator"}
+    # Keep recognized upstream options non-fatal during migration, but discard
+    # them before extracting the typed native search configuration in Rust.
+    unsupported = {
+        "fields",
+        "indexing",
+        "jieba_dict",
+        "jieba_dict_user",
+        "lang",
+        "min_search_length",
+        "pipeline",
+        "prebuild_index",
+    }
+    _reject_unknown_options("search", search, supported | unsupported)
+    for name in sorted(unsupported & search.keys()):
+        search.pop(name)
     set_default(search, "enabled", True)
     set_default(search, "separator", '[\\s\\-_,:!=\\[\\]()\\\\"`/]+|\\.(?!\\d)')
     _validate_boolean_options("search", search, ("enabled",))


### PR DESCRIPTION
Issue #926.

Previously known/working options are ignored instead of failing the build.
This PR is accompanied by a documentation update: https://github.com/zensical/docs/pull/172.