### PR TITLE
fix: relax validation of autorefs settings

### DIFF
--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -572,8 +572,14 @@ class TestPluginShimming:
             )
 
     def test_autorefs_standalone(self, tmp_path: Path) -> None:
-        config = self._parse_yaml(tmp_path, plugins={"autorefs": {}})
+        options = {
+            "resolve_closest": True,
+            "link_titles": "external",
+            "strip_title_tags": False,
+        }
+        config = self._parse_yaml(tmp_path, plugins={"autorefs": options})
         assert AutorefsExtension.name in config["markdown_extensions"]
+        assert config["plugins"]["autorefs"]["config"] == {}
 
     def test_autorefs_disabled_not_added(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/python/tests/unit/test_plugin_config.py
+++ b/python/tests/unit/test_plugin_config.py
@@ -266,6 +266,20 @@ def test_accepts_supported_shim_options(
 
 
 @pytest.mark.parametrize(
+    "option", ["resolve_closest", "link_titles", "strip_title_tags"]
+)
+@pytest.mark.parametrize(
+    "value", [True, False, "auto", "external", 42, [], {}, None]
+)
+def test_silently_discards_unsupported_autorefs_options(
+    option: str, value: Any, capsys: pytest.CaptureFixture[str]
+) -> None:
+    plugins = _convert_plugins({"autorefs": {"enabled": True, option: value}})
+    assert plugins["autorefs"]["config"] == {"enabled": True}
+    assert capsys.readouterr().err == ""
+
+
+@pytest.mark.parametrize(
     ("name", "config", "message"),
     [
         ("search", {"enabled": "yes"}, "enabled must be a boolean"),

--- a/python/zensical/config.py
+++ b/python/zensical/config.py
@@ -1695,8 +1695,16 @@ def _convert_plugins(value: Any, config: dict) -> dict:
     # Validate settings forwarded by the plugin-to-extension shims.
     if "autorefs" in plugins:
         autorefs = plugins["autorefs"]
-        _reject_unknown_options("autorefs", autorefs, {"enabled"})
+        _reject_unknown_options(
+            "autorefs",
+            autorefs,
+            {"enabled", "resolve_closest", "link_titles", "strip_title_tags"},
+        )
         _validate_boolean_options("autorefs", autorefs, ("enabled",))
+        # Ignore these upstream settings: the Rust resolver currently uses
+        # fixed resolution and title behavior.
+        for name in ("resolve_closest", "link_titles", "strip_title_tags"):
+            autorefs.pop(name, None)
 
     if "markdown-exec" in plugins:
         markdown_exec = plugins["markdown-exec"]


### PR DESCRIPTION
Quick fix for the second issue reported in https://github.com/zensical/zensical/issues/926#issuecomment-5637953810. Ideally we next run a full pass on supported plugins, their options, and how we validate/support them.

Previously known options:

- `resolve_closest`: now always true
- `link_titles`: now always true
- `strip_title_tags`: now always false