### PR TITLE
chore: release v0.0.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "zensical"
-version = "0.0.60"
+version = "0.0.61"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "zensical-serve"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "base64",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ all = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 
 [workspace.dependencies]
-zensical-serve = { version = "0.0.6", path = "crates/zensical-serve" }
+zensical-serve = { version = "0.0.7", path = "crates/zensical-serve" }
 zensical-watch = { version = "0.0.6", path = "crates/zensical-watch" }
 
 ahash = "0.8"

--- a/crates/zensical-serve/Cargo.toml
+++ b/crates/zensical-serve/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical-serve"
-version = "0.0.6"
+version = "0.0.7"
 description = "HTTP server"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/zensical/Cargo.toml
+++ b/crates/zensical/Cargo.toml
@@ -23,7 +23,7 @@
 
 [package]
 name = "zensical"
-version = "0.0.60"
+version = "0.0.61"
 description = "Zensical"
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

This version adds comprehensive support for documentation redirects in `mkdocs.yml` and `zensical.toml`. Zensical supports page and anchor redirects, resolves redirect chains, rejects cycles, and preserves links when pages are moved or split.

### Anchor redirects

Renaming a heading normally breaks bookmarks and external links to its old anchor. For example, after renaming `## Installation` to `## Getting started`, add:

```toml
[project.plugins.redirects.redirect_maps]
"guide.md#installation" = "guide.md#getting-started"
```

Existing links to `/guide/#installation` will then redirect to `/guide/#getting-started`. The same configuration can redirect anchors between pages or preserve individual sections when splitting a page.

### Automatic redirects

[Zensical Studio](https://zensical.org/studio/) detects renamed headings and offers an **Add anchor redirect** CodeLens. It can complete, validate, navigate to, and repair redirect targets while compacting repeated changes, updating redirect chains, and removing redundant self-redirects.

<img width="557" height="86" src="https://github.com/user-attachments/assets/802d8d99-a205-44af-a29f-6a26eaaa5780" />